### PR TITLE
feat: DRX template creation script and Phase 5 unit tests

### DIFF
--- a/scripts/05_resolve_setup.py
+++ b/scripts/05_resolve_setup.py
@@ -122,14 +122,13 @@ def load_scene_analysis(scene_analysis_dir: Path, clip_id: str) -> list[dict]:
     return data["subjects"]
 
 
-def classify_subject(label: str) -> int | None:
+def classify_subject(label: str) -> int:
     """Map a subject label to its target node index.
 
     Returns:
         NODE_DIVER (5) for diver subjects,
         NODE_MARINE_LIFE (6) for marine life subjects,
-        NODE_FOREGROUND_POP (4) for other identifiable subjects,
-        or None if the label cannot be classified.
+        NODE_FOREGROUND_POP (4) for all other subjects.
     """
     label_lower = label.lower()
 
@@ -803,7 +802,7 @@ def main():
     if drx_path_str is None:
         logger.warning(
             "DRX template not found at %s. 8-node grade structure will not be "
-            "deployed. Place the template file manually or create it in Resolve.",
+            "deployed. Generate it with: python scripts/create_drx_template.py",
             drx_path,
         )
 

--- a/scripts/create_drx_template.py
+++ b/scripts/create_drx_template.py
@@ -31,6 +31,7 @@ Architecture doc: Section 5.1
 """
 
 import argparse
+import importlib
 import logging
 import sys
 import tempfile
@@ -40,17 +41,9 @@ from pipeline_utils import configure_logging, find_workspace_root, load_config
 
 logger = logging.getLogger(__name__)
 
-# Node labels must match the constants in 05_resolve_setup.py
-NODE_LABELS = {
-    1: "Base LUT",
-    2: "Neutral Balance",
-    3: "Depth Grade",
-    4: "Foreground Pop",
-    5: "Diver",
-    6: "Marine Life",
-    7: "Creative Look",
-    8: "Output",
-}
+# Import node constants from 05_resolve_setup to keep them in sync
+_resolve_setup = importlib.import_module("05_resolve_setup")
+NODE_NAMES = _resolve_setup.NODE_NAMES
 
 TOTAL_NODES = 8
 TEMP_PROJECT_NAME = "_DRX_Template_Generator"
@@ -70,20 +63,24 @@ def create_test_image(output_path: Path) -> Path:
     except ImportError:
         pass
 
-    # Fallback: write a minimal valid PNG manually (1x1 black pixel)
+    # Fallback: write a minimal valid 64x64 black PNG manually
     # PNG signature + IHDR + IDAT + IEND
     import struct
     import zlib
+
+    width, height = 64, 64
 
     def _chunk(chunk_type: bytes, data: bytes) -> bytes:
         raw = chunk_type + data
         return struct.pack(">I", len(data)) + raw + struct.pack(">I", zlib.crc32(raw) & 0xFFFFFFFF)
 
     signature = b"\x89PNG\r\n\x1a\n"
-    ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)  # 1x1, 8-bit RGB
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)  # 64x64, 8-bit RGB
     ihdr = _chunk(b"IHDR", ihdr_data)
-    raw_row = b"\x00" + b"\x00\x00\x00"  # filter byte + 1 RGB pixel (black)
-    idat = _chunk(b"IDAT", zlib.compress(raw_row))
+    # Each row: filter byte (0) + width * 3 bytes RGB (all zeros = black)
+    raw_row = b"\x00" + b"\x00" * (width * 3)
+    raw_data = raw_row * height
+    idat = _chunk(b"IDAT", zlib.compress(raw_data))
     iend = _chunk(b"IEND", b"")
 
     output_path.write_bytes(signature + ihdr + idat + iend)
@@ -119,27 +116,33 @@ def connect_to_resolve():
 def create_temp_project(resolve):
     """Create a temporary project for DRX generation.
 
-    Returns (project_manager, project) tuple, or (None, None) on failure.
+    Returns (project_manager, project, original_project_name) tuple.
+    Returns (None, None, None) on failure.
     """
     try:
         pm = resolve.GetProjectManager()
     except Exception as e:
         logger.error("Failed to get ProjectManager: %s", e)
-        return None, None
+        return None, None, None
 
     if pm is None:
         logger.error("ProjectManager is None")
-        return None, None
+        return None, None, None
 
-    # Save reference to current project so we can switch back
+    # Save reference to current project so we can restore it after cleanup
+    original_name = None
     try:
         current_project = pm.GetCurrentProject()
-        current_name = current_project.GetName() if current_project else None
+        original_name = current_project.GetName() if current_project else None
     except Exception:
-        current_name = None
+        pass
 
     # Delete old temp project if it exists (from a previous failed run)
     try:
+        existing = pm.GetCurrentProject()
+        if existing and existing.GetName() == TEMP_PROJECT_NAME:
+            pm.CloseProject(existing)
+        logger.info("Deleting leftover temp project: %s", TEMP_PROJECT_NAME)
         pm.DeleteProject(TEMP_PROJECT_NAME)
     except Exception:
         pass
@@ -148,14 +151,14 @@ def create_temp_project(resolve):
         project = pm.CreateProject(TEMP_PROJECT_NAME)
     except Exception as e:
         logger.error("Failed to create temp project: %s", e)
-        return pm, None
+        return pm, None, original_name
 
     if project is None:
         logger.error("CreateProject returned None for '%s'", TEMP_PROJECT_NAME)
-        return pm, None
+        return pm, None, original_name
 
     logger.info("Created temp project: %s", TEMP_PROJECT_NAME)
-    return pm, project
+    return pm, project, original_name
 
 
 def setup_timeline_with_test_clip(project, test_image_path: Path):
@@ -268,7 +271,7 @@ def build_node_graph(timeline_item) -> bool:
 
     # Label each node
     label_failures = 0
-    for node_index, label in NODE_LABELS.items():
+    for node_index, label in NODE_NAMES.items():
         try:
             result = timeline_item.LabelNode(node_index, label)
             if result:
@@ -322,14 +325,16 @@ def export_drx(timeline_item, output_path: Path) -> bool:
         return False
 
 
-def cleanup_temp_project(project_manager):
-    """Delete the temporary project used for DRX generation."""
+def cleanup_temp_project(project_manager, original_project_name: str | None = None):
+    """Delete the temporary project and restore the user's original project."""
     if project_manager is None:
         return
 
+    # Only close if the current project is actually our temp project
     try:
-        # Switch away from the temp project first
-        project_manager.CloseProject(project_manager.GetCurrentProject())
+        current = project_manager.GetCurrentProject()
+        if current and current.GetName() == TEMP_PROJECT_NAME:
+            project_manager.CloseProject(current)
     except Exception:
         pass
 
@@ -342,6 +347,17 @@ def cleanup_temp_project(project_manager):
             "Delete it manually in Resolve's Project Manager.",
             TEMP_PROJECT_NAME, e,
         )
+
+    # Restore the user's original project
+    if original_project_name:
+        try:
+            project_manager.LoadProject(original_project_name)
+            logger.info("Restored original project: %s", original_project_name)
+        except Exception:
+            logger.info(
+                "Could not restore project '%s'. Reopen it manually in Resolve.",
+                original_project_name,
+            )
 
 
 def main():
@@ -393,14 +409,39 @@ def main():
 
     if args.export_only:
         # Export from the current project's first timeline item
-        try:
-            project = resolve.GetProjectManager().GetCurrentProject()
-            timeline = project.GetCurrentTimeline()
-            items = timeline.GetItemListInTrack("video", 1)
-            item = items[0]
-        except Exception as e:
-            logger.error("Failed to get current timeline item for --export-only: %s", e)
+        pm = resolve.GetProjectManager()
+        if pm is None:
+            logger.error("Failed to get ProjectManager")
             sys.exit(1)
+
+        project = pm.GetCurrentProject()
+        if project is None:
+            logger.error("No project is currently open in Resolve")
+            sys.exit(1)
+
+        timeline = project.GetCurrentTimeline()
+        if timeline is None:
+            logger.error("No timeline is selected in project '%s'", project.GetName())
+            sys.exit(1)
+
+        items = timeline.GetItemListInTrack("video", 1)
+        if not items:
+            logger.error("No clips on video track 1 of timeline '%s'", timeline.GetName())
+            sys.exit(1)
+
+        item = items[0]
+
+        # Validate node count before exporting
+        try:
+            node_count = item.GetNumNodes()
+            if node_count != TOTAL_NODES:
+                logger.warning(
+                    "Grade has %d nodes, expected %d. The exported DRX may not "
+                    "work correctly with Phase 5 (which expects nodes at indices 1-8).",
+                    node_count, TOTAL_NODES,
+                )
+        except Exception:
+            logger.debug("Could not verify node count (GetNumNodes not available)")
 
         if not export_drx(item, output_path):
             sys.exit(1)
@@ -409,6 +450,7 @@ def main():
 
     # Full automated flow
     project_manager = None
+    original_name = None
     try:
         # Create test image in temp directory
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -417,7 +459,7 @@ def main():
             logger.debug("Created test image: %s", test_image)
 
             # Create temp project
-            project_manager, project = create_temp_project(resolve)
+            project_manager, project, original_name = create_temp_project(resolve)
             if project is None:
                 sys.exit(1)
 
@@ -440,7 +482,7 @@ def main():
                     "  4. Label nodes: %s\n"
                     "  5. Right-click -> Export -> Export LUT/Grade as DRX\n"
                     "  6. Save to: %s",
-                    ", ".join(NODE_LABELS.values()),
+                    ", ".join(NODE_NAMES.values()),
                     output_path,
                 )
                 sys.exit(1)
@@ -450,9 +492,9 @@ def main():
                 sys.exit(1)
 
     finally:
-        # Clean up temp project
+        # Clean up temp project and restore original
         if not args.no_cleanup and project_manager is not None:
-            cleanup_temp_project(project_manager)
+            cleanup_temp_project(project_manager, original_name)
 
     logger.info("Done. DRX template created at: %s", output_path)
     logger.info(

--- a/scripts/pipeline_utils.py
+++ b/scripts/pipeline_utils.py
@@ -10,7 +10,6 @@ import re
 import sys
 from pathlib import Path
 
-import numpy as np
 import yaml
 
 logger = logging.getLogger(__name__)
@@ -20,7 +19,7 @@ logger = logging.getLogger(__name__)
 # D-Log M transfer function (DJI Action 4)
 # ---------------------------------------------------------------------------
 
-def dlog_m_to_linear(x: np.ndarray) -> np.ndarray:
+def dlog_m_to_linear(x):
     """Convert D-Log M encoded values to scene-linear light.
 
     D-Log M is DJI's log gamma curve used in Action 4 and other cameras.
@@ -34,6 +33,7 @@ def dlog_m_to_linear(x: np.ndarray) -> np.ndarray:
     Camera model: DJI Action 4 (D-Log M). If using a different DJI camera,
     verify these constants match its published curve.
     """
+    import numpy as np
     x = np.asarray(x, dtype=np.float64)
 
     # D-Log M curve parameters (DJI published curve)
@@ -63,11 +63,12 @@ def dlog_m_to_linear(x: np.ndarray) -> np.ndarray:
     return np.clip(linear, 0.0, None)
 
 
-def linear_to_dlog_m(x: np.ndarray) -> np.ndarray:
+def linear_to_dlog_m(x):
     """Convert scene-linear light values to D-Log M encoding.
 
     Inverse of dlog_m_to_linear(). Used for verification.
     """
+    import numpy as np
     x = np.asarray(x, dtype=np.float64)
 
     a = 0.9892

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -2,10 +2,10 @@
 # Master overnight batch script for Dorea pipeline
 # Runs Phases 1-4 inside the devcontainer, then prompts for Phase 5 on host.
 #
-# Usage: bash scripts/run_all.sh
+# Usage: bash scripts/run_all.sh [YYYY-MM-DD]
+#        Defaults to today's date if no argument given.
 #
 # Requires:
-#   - Python venv activated (source /opt/dorea-venv/bin/activate)
 #   - config.yaml configured with correct paths
 #   - Footage dumped to footage/raw/ and/or footage/flat/
 #
@@ -14,7 +14,13 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DATE=$(date +%Y-%m-%d)
+DATE="${1:-$(date +%Y-%m-%d)}"
+
+# Activate venv if not already active
+if [ -z "$VIRTUAL_ENV" ] && [ -f /opt/dorea-venv/bin/activate ]; then
+    # shellcheck disable=SC1091
+    source /opt/dorea-venv/bin/activate
+fi
 
 echo "=== Dorea Pipeline — $DATE ==="
 echo ""
@@ -25,7 +31,7 @@ echo ""
 
 # DRX template (create_drx_template.py) is also one-time — run on the HOST with
 # Resolve to generate templates/underwater_grade_v1.drx before first Phase 5 run.
-# Run manually: python scripts/create_drx_template.py
+# On the host: python scripts/create_drx_template.py
 
 echo "=== Phase 1: Extract keyframes ==="
 python "$SCRIPT_DIR/01_extract_frames.py" --date "$DATE"
@@ -45,7 +51,7 @@ echo ""
 echo "Phase 5 must run on the HOST (requires DaVinci Resolve)."
 echo "Open a terminal on the host and run:"
 echo ""
-echo "  cd $(dirname "$SCRIPT_DIR")"
+echo "  cd <your-workspace-root>/repos/dorea"
 echo "  python scripts/05_resolve_setup.py --date $DATE"
 echo ""
 echo "Then open Resolve — your timeline is ready for creative grading."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,4 +6,4 @@ from pathlib import Path
 # Add scripts/ to sys.path so tests can import pipeline modules
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_DIR))
+    sys.path.append(str(SCRIPTS_DIR))

--- a/tests/test_resolve_setup.py
+++ b/tests/test_resolve_setup.py
@@ -24,6 +24,7 @@ discover_footage = resolve_setup.discover_footage
 load_scene_analysis = resolve_setup.load_scene_analysis
 find_mask_sequence_dir = resolve_setup.find_mask_sequence_dir
 find_depth_sequence_dir = resolve_setup.find_depth_sequence_dir
+get_first_frame_path = resolve_setup.get_first_frame_path
 
 NODE_FOREGROUND_POP = resolve_setup.NODE_FOREGROUND_POP
 NODE_DIVER = resolve_setup.NODE_DIVER
@@ -258,3 +259,30 @@ class TestFindDepthSequenceDir:
         depth_dir.mkdir()
         result = find_depth_sequence_dir(tmp_path, "clip1")
         assert result is None
+
+
+# --- get_first_frame_path ---
+
+
+class TestGetFirstFramePath:
+    def test_returns_first_sorted(self, tmp_path):
+        (tmp_path / "frame_0003.png").write_bytes(b"c")
+        (tmp_path / "frame_0001.png").write_bytes(b"a")
+        (tmp_path / "frame_0002.png").write_bytes(b"b")
+
+        result = get_first_frame_path(tmp_path)
+        assert result == str(tmp_path / "frame_0001.png")
+
+    def test_empty_dir(self, tmp_path):
+        result = get_first_frame_path(tmp_path)
+        assert result is None
+
+    def test_non_png_excluded(self, tmp_path):
+        (tmp_path / "frame_0001.jpg").write_bytes(b"not png")
+        result = get_first_frame_path(tmp_path)
+        assert result is None
+
+    def test_single_frame(self, tmp_path):
+        (tmp_path / "frame_0001.png").write_bytes(b"only one")
+        result = get_first_frame_path(tmp_path)
+        assert result == str(tmp_path / "frame_0001.png")


### PR DESCRIPTION
## Summary
- Add `scripts/create_drx_template.py` — host-side Resolve API script that programmatically creates the 8-node serial grade structure and exports it as `.drx`
- Add 32 unit tests for Phase 5 pipeline logic (`classify_subject`, `assign_subjects_to_nodes`, `discover_footage`, `load_scene_analysis`, `find_mask_sequence_dir`, `find_depth_sequence_dir`, `get_first_frame_path`)
- Fix `pipeline_utils.py` numpy import to be lazy (enables host scripts without numpy)
- Update `run_all.sh` to accept date argument, auto-activate venv, document DRX prerequisite

## Changes
- **New**: `scripts/create_drx_template.py` — connects to Resolve, creates temp project, builds 8-node grade, exports DRX. Includes `--export-only` for manual workflows and `--no-cleanup` for debugging
- **New**: `tests/conftest.py` + `tests/test_resolve_setup.py` — 32 pytest tests
- **Modified**: `scripts/pipeline_utils.py` — lazy numpy import (D-Log M functions only)
- **Modified**: `scripts/05_resolve_setup.py` — fix `classify_subject` type hint, DRX warning mentions `create_drx_template.py`
- **Modified**: `scripts/run_all.sh` — accept `$1` date arg, auto-activate venv, fix host path in Phase 5 instructions

## Test Plan
- [x] All 32 unit tests pass (`pytest tests/ -v`)
- [x] All scripts compile (`py_compile`)
- [x] Dry-run validation with real footage (2025-11-01): 2 clips, scene analysis, depth maps verified
- [x] `create_drx_template.py --help` works correctly
- [x] DRX-missing warning now references `create_drx_template.py`
- [ ] Live Resolve E2E (requires host with Resolve running — cannot test from devcontainer)

## Review
5-persona review completed:
- Senior SWE: 4 Important, 4 Low/Minor — all fixed
- Product Manager: 2 Critical (scope), 3 Important — addressed (DRX creation requires Resolve on host)
- QA Engineer: 3 Important, 4 Low/Minor — all fixed
- SRE/Platform: 4 Important, 4 Low — all fixed
- DevEx: 2 Critical, 3 Important, 2 Low — all fixed

Addresses chunzhe10/dorea-workspace#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)