### PR TITLE
fix: resolve inference GPU startup bugs (depth, RAUNE-Net, build.rs)

### DIFF
--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -50,7 +50,8 @@ pub struct GradeArgs {
     #[arg(long)]
     pub raune_weights: Option<PathBuf>,
 
-    /// Path to RAUNE-Net models dir (sea_thru_poc directory)
+    /// Path to RAUNE-Net checkout directory (contains models/raune_net.py).
+    /// Also accepts the parent sea_thru_poc dir — auto-descends to RAUNE-Net/.
     #[arg(long)]
     pub raune_models_dir: Option<PathBuf>,
 

--- a/crates/dorea-cli/src/preview.rs
+++ b/crates/dorea-cli/src/preview.rs
@@ -45,7 +45,8 @@ pub struct PreviewArgs {
     #[arg(long)]
     pub raune_weights: Option<PathBuf>,
 
-    /// Path to RAUNE-Net models dir (sea_thru_poc directory)
+    /// Path to RAUNE-Net checkout directory (contains models/raune_net.py).
+    /// Also accepts the parent sea_thru_poc dir — auto-descends to RAUNE-Net/.
     #[arg(long)]
     pub raune_models_dir: Option<PathBuf>,
 

--- a/crates/dorea-gpu/build.rs
+++ b/crates/dorea-gpu/build.rs
@@ -90,6 +90,7 @@ fn main() {
             "-O2".to_string(),
             "-arch=sm_86".to_string(), // RTX 3060 is Ampere sm_86
             "--compiler-options=-fPIC".to_string(),
+            "--allow-unsupported-compiler".to_string(), // GCC 14 > officially supported max (13)
         ];
         if let Some(ref inc) = cuda_include {
             args.push("-isystem".to_string());
@@ -105,7 +106,12 @@ fn main() {
             .expect("failed to run nvcc");
 
         if !status.success() {
-            panic!("nvcc failed to compile {name}.cu");
+            println!(
+                "cargo:warning=nvcc failed to compile {name}.cu — \
+                 falling back to CPU-only (GCC/CUDA version mismatch?). \
+                 Install gcc-12 or gcc-13 and set CUDAHOSTCXX to enable CUDA kernels."
+            );
+            return;
         }
         obj_files.push(obj);
     }

--- a/crates/dorea-video/src/inference.rs
+++ b/crates/dorea-video/src/inference.rs
@@ -83,9 +83,9 @@ impl InferenceServer {
 
         if let Some(p) = &config.depth_model {
             cmd.args(["--depth-model", p.to_str().unwrap_or("")]);
-        } else {
-            cmd.arg("--no-depth");
         }
+        // depth_model = None means "use the Python-side default path / HF fallback"
+        // do NOT pass --no-depth unless explicitly requested
 
         if let Some(d) = &config.device {
             cmd.args(["--device", d]);

--- a/python/dorea_inference/raune_net.py
+++ b/python/dorea_inference/raune_net.py
@@ -15,7 +15,9 @@ import numpy as np
 
 # Default location relative to workspace root.
 # __file__ is python/dorea_inference/raune_net.py → parents[4] = workspace root
-_DEFAULT_RAUNE_MODELS_DIR = Path(__file__).parents[4] / "working" / "sea_thru_poc"
+_DEFAULT_RAUNE_MODELS_DIR = (
+    Path(__file__).parents[4] / "working" / "sea_thru_poc" / "models" / "RAUNE-Net"
+)
 _DEFAULT_WEIGHTS = (
     Path(__file__).parents[4]
     / "working" / "sea_thru_poc" / "models" / "RAUNE-Net"
@@ -49,8 +51,17 @@ class RauneNetInference:
 
         self.device = torch.device(device if torch.cuda.is_available() or device == "cpu" else "cpu")
 
-        # Add the sea_thru_poc directory to sys.path so we can import models.raune_net
-        models_dir = Path(raune_models_dir) if raune_models_dir else _DEFAULT_RAUNE_MODELS_DIR
+        # Add the RAUNE-Net directory to sys.path so we can import models.raune_net.
+        # Accepts either the RAUNE-Net dir directly (has models/raune_net.py) or the
+        # parent sea_thru_poc dir (auto-descends to models/RAUNE-Net/).
+        given = Path(raune_models_dir) if raune_models_dir else _DEFAULT_RAUNE_MODELS_DIR
+        if (given / "models" / "raune_net.py").exists():
+            models_dir = given
+        elif (given / "models" / "RAUNE-Net" / "models" / "raune_net.py").exists():
+            models_dir = given / "models" / "RAUNE-Net"
+        else:
+            models_dir = given  # let the import fail with a clear error below
+
         if str(models_dir) not in sys.path:
             sys.path.insert(0, str(models_dir))
 
@@ -59,7 +70,8 @@ class RauneNetInference:
         except ImportError as e:
             raise ImportError(
                 f"Could not import RauneNet from {models_dir}/models/raune_net.py: {e}\n"
-                f"Ensure --raune-models-dir points to the sea_thru_poc directory."
+                f"Pass --raune-models-dir pointing to the RAUNE-Net checkout directory "
+                f"(the one that contains a models/raune_net.py file)."
             ) from e
 
         weights = Path(weights_path) if weights_path else _DEFAULT_WEIGHTS
@@ -69,7 +81,7 @@ class RauneNetInference:
                 "Pass --raune-weights to specify the .pth file."
             )
 
-        self.model = RauneNet().to(self.device)
+        self.model = RauneNet(input_nc=3, output_nc=3, n_blocks=30, n_down=2).to(self.device)
         state = torch.load(str(weights), map_location=self.device, weights_only=False)
         self.model.load_state_dict(state)
         self.model.eval()


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during the first full-resolution GPU pipeline test on `footage/raw/2025-11-01`.

- **Depth Anything not loading**: `inference.rs` was passing `--no-depth` whenever `--depth-model` was omitted from the CLI. Fixed to let the Python server use its default path (`models/depth_anything_v2_small`) or HF hub fallback.
- **RAUNE-Net TypeError at runtime**: `RauneNet()` was called with no args; the constructor requires `input_nc`, `output_nc`, `n_blocks`, `n_down`. Fixed with correct defaults matching the pretrained checkpoint.
- **Wrong default `raune_models_dir`**: Default path pointed to `sea_thru_poc/` but the import expects the `RAUNE-Net/` subdirectory. Fixed default + added auto-descent so both paths work.
- **`build.rs` panic on nvcc failure**: GCC 14 + CUDA 12.4 incompatibility (issue #6) caused a panic instead of graceful CPU fallback. Fixed to warn and continue.

## Test plan

- [x] `dorea preview` runs end-to-end with RAUNE-Net + Depth Anything both on `cuda`
- [x] Auto-calibrates from sampled frames, saves `preview.png` successfully
- [x] `--raune-models-dir working/sea_thru_poc` (parent dir) now works via auto-descent
- [x] `cargo build --release` succeeds with CPU fallback when nvcc fails

Closes #6 workaround (GCC fix still tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)