### PR TITLE
perf: proxy resize before depth inference + O(N) box blur (CPU fallback)

### DIFF
--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -138,13 +138,29 @@ pub fn run(args: GradeArgs) -> Result<()> {
             // TODO(Phase 3+): trigger re-calibration on scene cut
         }
 
+        // Downscale to proxy resolution before sending to inference.
+        // Avoids serializing 24 MB/frame over the pipe when Python resizes to 518 px anyway.
+        let (proxy_w, proxy_h) =
+            dorea_video::resize::proxy_dims(frame.width, frame.height, args.proxy_size);
+        let proxy_pixels = if proxy_w != frame.width || proxy_h != frame.height {
+            dorea_video::resize::resize_rgb_bilinear(
+                &frame.pixels,
+                frame.width,
+                frame.height,
+                proxy_w,
+                proxy_h,
+            )
+        } else {
+            frame.pixels.clone()
+        };
+
         // Run depth inference at proxy resolution
         let (depth_proxy, dw, dh) = inf_server
             .run_depth(
                 &frame.index.to_string(),
-                &frame.pixels,
-                frame.width,
-                frame.height,
+                &proxy_pixels,
+                proxy_w,
+                proxy_h,
                 args.proxy_size,
             )
             .unwrap_or_else(|e| {

--- a/crates/dorea-gpu/src/cpu.rs
+++ b/crates/dorea-gpu/src/cpu.rs
@@ -222,8 +222,8 @@ fn three_pass_box_blur(input: &[f32], width: usize, height: usize, radius: usize
     let mut buf_a = input.to_vec();
     let mut buf_b = vec![0.0_f32; input.len()];
     for _ in 0..3 {
-        box_blur_rows(&buf_a, &mut buf_b, width, height, radius);
-        box_blur_cols(&buf_b, &mut buf_a, width, height, radius);
+        box_blur_rows_sliding(&buf_a, &mut buf_b, width, height, radius);
+        box_blur_cols_via_transpose(&buf_b, &mut buf_a, width, height, radius);
     }
     buf_a
 }
@@ -240,6 +240,64 @@ fn box_blur_rows(src: &[f32], dst: &mut [f32], width: usize, height: usize, radi
                 s += src[base + k];
             }
             dst[base + col] = s / (hi - lo + 1) as f32;
+        }
+    }
+}
+
+/// Sliding-window box blur over rows. O(W) per row — replaces the naive O(W×radius) version.
+fn box_blur_rows_sliding(src: &[f32], dst: &mut [f32], width: usize, height: usize, radius: usize) {
+    let r = radius as isize;
+    for row in 0..height {
+        let base = row * width;
+        let mut sum = 0.0f32;
+        let mut count = 0usize;
+
+        // Seed window for col=0: indices [0..min(r, W-1)]
+        let init_hi = r.min(width as isize - 1) as usize;
+        for k in 0..=init_hi {
+            sum += src[base + k];
+            count += 1;
+        }
+
+        for col in 0..width {
+            dst[base + col] = sum / count as f32;
+
+            // Expand right edge for next column
+            let add = col as isize + r + 1;
+            if add < width as isize {
+                sum += src[base + add as usize];
+                count += 1;
+            }
+            // Shrink left edge for next column
+            let rem = col as isize - r;
+            if rem >= 0 {
+                sum -= src[base + rem as usize];
+                count -= 1;
+            }
+        }
+    }
+}
+
+/// Column box blur using transpose → row blur → transpose back.
+/// Avoids the strided-memory cache thrash of direct column access.
+fn box_blur_cols_via_transpose(
+    src: &[f32],
+    dst: &mut [f32],
+    width: usize,
+    height: usize,
+    radius: usize,
+) {
+    let mut transposed = vec![0.0f32; width * height];
+    for row in 0..height {
+        for col in 0..width {
+            transposed[col * height + row] = src[row * width + col];
+        }
+    }
+    let mut blurred_t = vec![0.0f32; width * height];
+    box_blur_rows_sliding(&transposed, &mut blurred_t, height, width, radius);
+    for row in 0..height {
+        for col in 0..width {
+            dst[row * width + col] = blurred_t[col * height + row];
         }
     }
 }
@@ -348,6 +406,58 @@ mod tests {
         // Values should remain in [0, 1]
         for &v in &rgb {
             assert!((0.0..=1.0).contains(&v), "out-of-range: {v}");
+        }
+    }
+
+    #[test]
+    fn box_blur_rows_sliding_matches_naive_small() {
+        let src: Vec<f32> = vec![
+            1.0, 2.0, 3.0, 4.0, 5.0,
+            5.0, 4.0, 3.0, 2.0, 1.0,
+        ];
+        let mut dst_sliding = vec![0.0f32; 10];
+        let mut dst_naive   = vec![0.0f32; 10];
+        box_blur_rows_sliding(&src, &mut dst_sliding, 5, 2, 1);
+        box_blur_rows(&src, &mut dst_naive, 5, 2, 1);
+        for (a, b) in dst_sliding.iter().zip(dst_naive.iter()) {
+            assert!((a - b).abs() < 1e-5, "mismatch: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn box_blur_rows_sliding_radius_zero() {
+        let src: Vec<f32> = vec![1.0, 2.0, 3.0];
+        let mut dst = vec![0.0f32; 3];
+        box_blur_rows_sliding(&src, &mut dst, 3, 1, 0);
+        assert_eq!(dst, src, "radius=0 should be identity");
+    }
+
+    #[test]
+    fn box_blur_rows_sliding_radius_exceeds_width() {
+        let src: Vec<f32> = vec![1.0, 2.0, 3.0];
+        let expected_mean = 2.0f32;
+        let mut dst = vec![0.0f32; 3];
+        box_blur_rows_sliding(&src, &mut dst, 3, 1, 100);
+        for v in &dst {
+            assert!((v - expected_mean).abs() < 1e-5, "expected {expected_mean}, got {v}");
+        }
+    }
+
+    #[test]
+    fn box_blur_cols_via_transpose_matches_naive_small() {
+        let src: Vec<f32> = vec![
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+            7.0, 8.0, 9.0,
+            6.0, 5.0, 4.0,
+            3.0, 2.0, 1.0,
+        ];
+        let mut dst_transpose = vec![0.0f32; 15];
+        let mut dst_naive     = vec![0.0f32; 15];
+        box_blur_cols_via_transpose(&src, &mut dst_transpose, 3, 5, 1);
+        box_blur_cols(&src, &mut dst_naive, 3, 5, 1);
+        for (i, (a, b)) in dst_transpose.iter().zip(dst_naive.iter()).enumerate() {
+            assert!((a - b).abs() < 1e-5, "pixel {i}: {a} vs {b}");
         }
     }
 

--- a/crates/dorea-video/src/lib.rs
+++ b/crates/dorea-video/src/lib.rs
@@ -10,4 +10,5 @@
 
 pub mod ffmpeg;
 pub mod inference;
+pub mod resize;
 pub mod scene;

--- a/crates/dorea-video/src/resize.rs
+++ b/crates/dorea-video/src/resize.rs
@@ -1,0 +1,109 @@
+// RGB frame resize utilities used by the grading pipeline.
+
+/// Compute `(proxy_w, proxy_h)` scaled so the long edge ≤ `max_size`.
+/// Returns the original dimensions unchanged if they are already within bounds.
+pub fn proxy_dims(src_w: usize, src_h: usize, max_size: usize) -> (usize, usize) {
+    let long_edge = src_w.max(src_h);
+    if long_edge <= max_size {
+        return (src_w, src_h);
+    }
+    let scale = max_size as f64 / long_edge as f64;
+    let pw = ((src_w as f64 * scale).round() as usize).max(1);
+    let ph = ((src_h as f64 * scale).round() as usize).max(1);
+    (pw, ph)
+}
+
+/// Bilinearly downsample an RGB24 frame.
+///
+/// `src` is interleaved RGB u8, length = `src_w * src_h * 3`.
+/// Returns interleaved RGB u8, length = `dst_w * dst_h * 3`.
+pub fn resize_rgb_bilinear(
+    src: &[u8],
+    src_w: usize,
+    src_h: usize,
+    dst_w: usize,
+    dst_h: usize,
+) -> Vec<u8> {
+    assert_eq!(src.len(), src_w * src_h * 3, "src length mismatch");
+    let mut out = vec![0u8; dst_w * dst_h * 3];
+    let sw = (src_w as f32 - 1.0).max(0.0);
+    let sh = (src_h as f32 - 1.0).max(0.0);
+    let dw = (dst_w as f32 - 1.0).max(1.0);
+    let dh = (dst_h as f32 - 1.0).max(1.0);
+    for dy in 0..dst_h {
+        for dx in 0..dst_w {
+            let sx = dx as f32 * sw / dw;
+            let sy = dy as f32 * sh / dh;
+            let x0 = sx.floor() as usize;
+            let y0 = sy.floor() as usize;
+            let x1 = (x0 + 1).min(src_w - 1);
+            let y1 = (y0 + 1).min(src_h - 1);
+            let fx = sx - x0 as f32;
+            let fy = sy - y0 as f32;
+            let out_base = (dy * dst_w + dx) * 3;
+            for c in 0..3 {
+                let v00 = src[(y0 * src_w + x0) * 3 + c] as f32;
+                let v10 = src[(y0 * src_w + x1) * 3 + c] as f32;
+                let v01 = src[(y1 * src_w + x0) * 3 + c] as f32;
+                let v11 = src[(y1 * src_w + x1) * 3 + c] as f32;
+                let v = v00 * (1.0 - fx) * (1.0 - fy)
+                      + v10 * fx * (1.0 - fy)
+                      + v01 * (1.0 - fx) * fy
+                      + v11 * fx * fy;
+                out[out_base + c] = v.round().clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_dims_no_change_when_within_bounds() {
+        assert_eq!(proxy_dims(518, 292, 518), (518, 292));
+        assert_eq!(proxy_dims(100, 50, 1000), (100, 50));
+    }
+
+    #[test]
+    fn proxy_dims_scales_down_landscape() {
+        let (pw, ph) = proxy_dims(3840, 2160, 518);
+        assert!(pw.max(ph) <= 518, "long edge {pw}×{ph} > 518");
+        let ratio_orig = 3840.0f64 / 2160.0;
+        let ratio_proxy = pw as f64 / ph as f64;
+        assert!((ratio_proxy - ratio_orig).abs() < 0.1, "aspect ratio {ratio_proxy} vs {ratio_orig}");
+    }
+
+    #[test]
+    fn proxy_dims_scales_down_portrait() {
+        let (pw, ph) = proxy_dims(1080, 1920, 518);
+        assert!(pw.max(ph) <= 518);
+    }
+
+    #[test]
+    fn resize_rgb_bilinear_dimensions() {
+        let src = vec![128u8; 4 * 4 * 3];
+        let dst = resize_rgb_bilinear(&src, 4, 4, 2, 2);
+        assert_eq!(dst.len(), 2 * 2 * 3);
+    }
+
+    #[test]
+    fn resize_rgb_bilinear_solid_color_preserved() {
+        let src = vec![200u8, 100u8, 50u8].repeat(16);
+        let dst = resize_rgb_bilinear(&src, 4, 4, 2, 2);
+        for chunk in dst.chunks_exact(3) {
+            assert_eq!(chunk[0], 200, "R channel changed");
+            assert_eq!(chunk[1], 100, "G channel changed");
+            assert_eq!(chunk[2], 50,  "B channel changed");
+        }
+    }
+
+    #[test]
+    fn resize_rgb_bilinear_identity_same_size() {
+        let src: Vec<u8> = (0u8..48).collect();
+        let dst = resize_rgb_bilinear(&src, 4, 4, 4, 4);
+        assert_eq!(dst, src, "same-size resize should be identity");
+    }
+}


### PR DESCRIPTION
## Summary

- **`grade.rs`**: downscale frame to proxy resolution (518 px long edge) in Rust before sending to Python depth inference — reduces per-frame pipe payload from **24 MB → ~200 KB** (120×). Python was resizing to proxy immediately anyway; now Rust does it first.
- **`dorea-video/src/resize.rs`** (new): `resize_rgb_bilinear` + `proxy_dims` utilities used by the grading loop.
- **`cpu.rs`**: replace O(N×radius) `box_blur_rows`/`box_blur_cols` with `box_blur_rows_sliding` (sliding window, O(N)) + `box_blur_cols_via_transpose` (transpose→row-blur→transpose, eliminates 15 KB column-stride cache misses). Used by the CPU-fallback clarity path.

## Before / After

| | Before | After |
|---|---|---|
| Depth inference pipe payload | 24 MB/frame (full 4K PNG) | ~200 KB/frame (518 px PNG) |
| Box blur (CPU fallback) | O(N×radius) — 9B iters @ 4K | O(N) sliding window + cache-friendly cols |

## Test Plan

- [x] 6 `dorea-video::resize` tests pass
- [x] 8 `dorea-gpu` tests pass (including box_blur sliding-window correctness vs naive)
- [x] Full workspace: 35 tests, 0 failures
- [x] `cargo build -p dorea-cli` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)