### PR TITLE
fix(grade): shut down inference server before pass 2 to free VRAM for NVENC

### DIFF
--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -303,6 +303,11 @@ pub fn run(args: GradeArgs) -> Result<()> {
     }
     log::info!("Batch depth inference complete ({} keyframes)", keyframes.len());
 
+    // Shut down inference server before pass 2 — all depths are cached in keyframe_depths.
+    // Releasing Depth Anything V2 VRAM (~1.5 GB) here avoids contention with NVENC input
+    // buffer allocation on RTX 3060 (6 GB VRAM).
+    let _ = inf_server.shutdown();
+
     // Ordered list of (frame_index, scene_cut_before) for pass-2 lerp lookup.
     let kf_index_list: Vec<(u64, bool)> = keyframes.iter()
         .map(|kf| (kf.frame_index, kf.scene_cut_before))
@@ -375,7 +380,6 @@ pub fn run(args: GradeArgs) -> Result<()> {
         }
     }
 
-    let _ = inf_server.shutdown();
     encoder.finish().context("ffmpeg encoder failed to finalize")?;
 
     if info.frame_count > 0 && frame_count < info.frame_count {


### PR DESCRIPTION
## Summary

`inf_server.shutdown()` was placed after pass 2, leaving Depth Anything V2 (~1.5 GB VRAM) loaded throughout the entire grading + encoding loop. On RTX 3060 (6 GB VRAM), NVENC's 4K input buffer allocation fails with OOM when the idle inference subprocess holds 1.5 GB.

Move shutdown to immediately after batch depth inference completes — all depths are cached in `keyframe_depths` at that point.

## VRAM at NVENC init (first `encoder.write_frame`)

| | Before | After |
|---|---|---|
| CUDA grader (PTX + LUT texture) | ~300 MB | ~300 MB |
| Depth Anything V2 subprocess | ~1.5 GB | **freed** |
| NVENC 4K input buffers | fails | allocates |

## Test plan

- [ ] `dorea grade --depth-max-interval 5 --keyframe-interval 5` on 41s DJI clip completes end-to-end
- [ ] Output file is non-empty and playable

🤖 Generated with [Claude Code](https://claude.com/claude-code)