### PR TITLE
feat(inference): fused RAUNE+depth batch — eliminate GPU idle in auto_calibrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "env_logger",
  "image",
  "log",
+ "memmap2",
 ]
 
 [[package]]
@@ -887,6 +888,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"

--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use dorea_cal::Calibration;
 use dorea_gpu::{grade_frame, GradeParams};
 use dorea_video::ffmpeg::{self, FrameEncoder};
-use dorea_video::inference::{DepthBatchItem, InferenceConfig, InferenceServer};
+use dorea_video::inference::{DepthBatchItem, RauneDepthBatchItem, InferenceConfig, InferenceServer};
 
 #[cfg(feature = "cuda")]
 use dorea_gpu::cuda::CudaGrader;
@@ -114,6 +114,10 @@ fn lerp_depth(a: &[f32], b: &[f32], t: f32) -> Vec<f32> {
 
 /// Maximum number of keyframes per depth inference batch.
 const DEPTH_BATCH_SIZE: usize = 32;
+
+/// Maximum frames per fused RAUNE+depth inference batch.
+/// Calibration images are ~1024×577; 8 frames ≈ 57 MB RAUNE input on GPU.
+const FUSED_BATCH_SIZE: usize = 8;
 
 /// A keyframe collected during the proxy-decode pass.
 struct KeyframeEntry {
@@ -542,7 +546,6 @@ fn auto_calibrate(args: &GradeArgs, info: &ffmpeg::VideoInfo) -> Result<Calibrat
     let kf_w = ((info.width as f64 * cal_scale) as usize).max(1);
     let kf_h = ((info.height as f64 * cal_scale) as usize).max(1);
 
-    // --- Collect keyframes: inference → paged store (one frame in RAM at a time) ---
     let inf_cfg = build_inference_config(args);
     let mut inf_server = InferenceServer::spawn(&inf_cfg)
         .context("failed to spawn inference server for auto-calibration")?;
@@ -550,36 +553,81 @@ fn auto_calibrate(args: &GradeArgs, info: &ffmpeg::VideoInfo) -> Result<Calibrat
     let mut store = PagedCalibrationStore::new()
         .context("failed to create paged calibration store")?;
 
+    // --- Phase 1: collect pixel buffers (N individual ffmpeg seeks — unchanged) ---
+    log::info!("Auto-calibration: extracting {n_kf} keyframes...");
+    let mut kf_pixels: Vec<Vec<u8>> = Vec::with_capacity(n_kf);
     for i in 0..n_kf {
         let ts = (i as f64 + 0.5) * safe_duration / n_kf as f64;
         let pixels = ffmpeg::extract_frame_at(&args.input, ts, kf_w, kf_h)
             .with_context(|| format!("failed to extract keyframe at {ts:.2}s"))?;
-
-        let id = format!("kf{i:04}");
-
-        let target = match inf_server.run_raune(&id, &pixels, kf_w, kf_h, kf_w) {
-            Ok((t, _, _)) => t,
-            Err(e) => {
-                log::warn!("RAUNE-Net failed for {id}: {e} — using original as target");
-                pixels.clone()
-            }
-        };
-
-        let (depth_proxy, dw, dh) = match inf_server.run_depth(&id, &pixels, kf_w, kf_h, 518) {
-            Ok(d) => d,
-            Err(e) => {
-                log::warn!("Depth failed for {id}: {e} — using uniform depth 0.5");
-                (vec![0.5f32; kf_w * kf_h], kf_w, kf_h)
-            }
-        };
-
-        let depth = InferenceServer::upscale_depth(&depth_proxy, dw, dh, kf_w, kf_h);
-
-        store.push(&pixels, &target, &depth, kf_w, kf_h)
-            .with_context(|| format!("failed to page frame {i} to disk"))?;
+        kf_pixels.push(pixels);
     }
+    log::info!("Collected {} keyframe pixels", kf_pixels.len());
+
+    // --- Phase 2: fused RAUNE+depth batch inference ---
+    // RAUNE output stays on GPU between models — no IPC round-trip for enhanced frames.
+    // Depth runs on RAUNE-enhanced frames for better zone boundaries.
+    log::info!(
+        "Fused RAUNE+depth inference ({} frames, batch_size={FUSED_BATCH_SIZE})...",
+        kf_pixels.len()
+    );
+
+    let fused_items: Vec<RauneDepthBatchItem> = kf_pixels.iter().enumerate().map(|(i, px)| {
+        RauneDepthBatchItem {
+            id: format!("kf{i:04}"),
+            pixels: px.clone(),
+            width: kf_w,
+            height: kf_h,
+            raune_max_size: kf_w,
+            depth_max_size: 518,
+        }
+    }).collect();
+
+    // (id, enhanced_rgb, enh_w, enh_h, depth_f32, depth_w, depth_h)
+    let mut kf_results: Vec<(Vec<u8>, Vec<f32>, usize, usize)> = Vec::with_capacity(n_kf);
+
+    for (chunk_items, chunk_pixels) in fused_items
+        .chunks(FUSED_BATCH_SIZE)
+        .zip(kf_pixels.chunks(FUSED_BATCH_SIZE))
+    {
+        let mut results = inf_server.run_raune_depth_batch(chunk_items)
+            .unwrap_or_else(|e| {
+                log::warn!("Fused RAUNE+depth batch failed: {e} — using originals + uniform depth");
+                chunk_items.iter().zip(chunk_pixels.iter()).map(|(item, px)| {
+                    (item.id.clone(), px.clone(), kf_w, kf_h,
+                     vec![0.5f32; kf_w * kf_h], kf_w, kf_h)
+                }).collect()
+            });
+
+        if results.len() < chunk_items.len() {
+            log::warn!(
+                "Fused batch returned {} results for {} items — padding with originals",
+                results.len(), chunk_items.len()
+            );
+            let have = results.len();
+            for (item, px) in chunk_items[have..].iter().zip(chunk_pixels[have..].iter()) {
+                results.push((item.id.clone(), px.clone(), kf_w, kf_h,
+                               vec![0.5f32; kf_w * kf_h], kf_w, kf_h));
+            }
+        }
+
+        for (_, enhanced, _, _, depth_raw, dw, dh) in results {
+            kf_results.push((enhanced, depth_raw, dw, dh));
+        }
+    }
+    log::info!("Fused inference complete: {} frames", kf_results.len());
 
     let _ = inf_server.shutdown();
+
+    // --- Phase 3: push to store ---
+    for (i, (pixels, (enhanced, depth_proxy, dw, dh))) in
+        kf_pixels.iter().zip(kf_results.iter()).enumerate()
+    {
+        let depth = InferenceServer::upscale_depth(depth_proxy, *dw, *dh, kf_w, kf_h);
+        store.push(pixels, enhanced, &depth, kf_w, kf_h)
+            .with_context(|| format!("failed to page frame {i} to store"))?;
+    }
+
     store.seal().context("failed to seal calibration store")?;
 
     // --- Pass 1: reservoir-sample depths → adaptive zone boundaries ---

--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -583,7 +583,7 @@ fn auto_calibrate(args: &GradeArgs, info: &ffmpeg::VideoInfo) -> Result<Calibrat
         }
     }).collect();
 
-    // (id, enhanced_rgb, enh_w, enh_h, depth_f32, depth_w, depth_h)
+    // (enhanced_rgb_u8, depth_f32_raw, depth_w, depth_h) — id and enh_w/h stripped on push
     let mut kf_results: Vec<(Vec<u8>, Vec<f32>, usize, usize)> = Vec::with_capacity(n_kf);
 
     for (chunk_items, chunk_pixels) in fused_items
@@ -620,9 +620,10 @@ fn auto_calibrate(args: &GradeArgs, info: &ffmpeg::VideoInfo) -> Result<Calibrat
     let _ = inf_server.shutdown();
 
     // --- Phase 3: push to store ---
-    debug_assert_eq!(
-        kf_results.len(), kf_pixels.len(),
-        "fused inference must produce exactly one result per keyframe before Phase 3"
+    anyhow::ensure!(
+        kf_results.len() == kf_pixels.len(),
+        "fused inference produced {} results for {} keyframes — calibration aborted",
+        kf_results.len(), kf_pixels.len()
     );
     for (i, (pixels, (enhanced, depth_proxy, dw, dh))) in
         kf_pixels.iter().zip(kf_results.iter()).enumerate()

--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -578,7 +578,7 @@ fn auto_calibrate(args: &GradeArgs, info: &ffmpeg::VideoInfo) -> Result<Calibrat
             pixels: px.clone(),
             width: kf_w,
             height: kf_h,
-            raune_max_size: kf_w,
+            raune_max_size: kf_w.max(kf_h),
             depth_max_size: 518,
         }
     }).collect();
@@ -620,6 +620,10 @@ fn auto_calibrate(args: &GradeArgs, info: &ffmpeg::VideoInfo) -> Result<Calibrat
     let _ = inf_server.shutdown();
 
     // --- Phase 3: push to store ---
+    debug_assert_eq!(
+        kf_results.len(), kf_pixels.len(),
+        "fused inference must produce exactly one result per keyframe before Phase 3"
+    );
     for (i, (pixels, (enhanced, depth_proxy, dw, dh))) in
         kf_pixels.iter().zip(kf_results.iter()).enumerate()
     {

--- a/crates/dorea-video/src/inference_subprocess.rs
+++ b/crates/dorea-video/src/inference_subprocess.rs
@@ -73,6 +73,19 @@ pub struct DepthBatchItem {
     pub max_size: usize,
 }
 
+/// A single image for the fused raune_depth_batch IPC call.
+pub struct RauneDepthBatchItem {
+    pub id: String,
+    /// Raw RGB24 pixels, row-major.
+    pub pixels: Vec<u8>,
+    pub width: usize,
+    pub height: usize,
+    /// Max long-edge for RAUNE resize (pixels).
+    pub raune_max_size: usize,
+    /// Max long-edge for depth resize (pixels, must be ≤518 for Depth Anything).
+    pub depth_max_size: usize,
+}
+
 /// Active connection to the Python inference subprocess.
 pub struct InferenceServer {
     child: Child,
@@ -379,6 +392,85 @@ impl InferenceServer {
             out.push((id, depth, w, h));
         }
 
+        Ok(out)
+    }
+
+    /// Run RAUNE then Depth Anything on a batch, with the enhanced tensor staying on GPU
+    /// between the two models. Returns enhanced RGB and depth map for each item.
+    ///
+    /// Returns `Vec<(id, enhanced_rgb_u8, enh_w, enh_h, depth_f32, depth_w, depth_h)>`.
+    #[allow(clippy::type_complexity)]
+    pub fn run_raune_depth_batch(
+        &mut self,
+        items: &[RauneDepthBatchItem],
+    ) -> Result<Vec<(String, Vec<u8>, usize, usize, Vec<f32>, usize, usize)>, InferenceError> {
+        if items.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let json_items: Vec<serde_json::Value> = items.iter().map(|item| {
+            serde_json::json!({
+                "id": item.id,
+                "image_b64": B64.encode(&item.pixels),
+                "format": "raw_rgb",
+                "width": item.width,
+                "height": item.height,
+                "raune_max_size": item.raune_max_size,
+                "depth_max_size": item.depth_max_size,
+            })
+        }).collect();
+
+        let req = serde_json::json!({ "type": "raune_depth_batch", "items": json_items });
+        self.send_line(&req.to_string())?;
+
+        let resp = self.recv_line()?;
+        let v: serde_json::Value = serde_json::from_str(&resp)
+            .map_err(|e| InferenceError::Ipc(format!("raune_depth_batch parse: {e}")))?;
+
+        if v["type"].as_str() == Some("error") {
+            return Err(InferenceError::ServerError(
+                v["message"].as_str().unwrap_or("unknown").to_string(),
+            ));
+        }
+        if v["type"].as_str() != Some("raune_depth_batch_result") {
+            return Err(InferenceError::Ipc(format!("unexpected type: {resp}")));
+        }
+
+        let results = v["results"].as_array()
+            .ok_or_else(|| InferenceError::Ipc("missing results array".to_string()))?;
+
+        let mut out = Vec::with_capacity(results.len());
+        for r in results {
+            let id = r["id"].as_str().unwrap_or("").to_string();
+
+            // Enhanced image (PNG-encoded)
+            let enh_w = r["enhanced_width"].as_u64().unwrap_or(0) as usize;
+            let enh_h = r["enhanced_height"].as_u64().unwrap_or(0) as usize;
+            let enh_b64 = r["image_b64"].as_str()
+                .ok_or_else(|| InferenceError::Ipc(format!("missing image_b64 for {id}")))?;
+            let enh_png = B64.decode(enh_b64)
+                .map_err(|e| InferenceError::Ipc(format!("base64 enh for {id}: {e}")))?;
+            let enh_rgb = decode_png_bytes(&enh_png)?;
+
+            // Depth map (raw f32 LE)
+            let depth_w = r["depth_width"].as_u64().unwrap_or(0) as usize;
+            let depth_h = r["depth_height"].as_u64().unwrap_or(0) as usize;
+            let depth_b64 = r["depth_f32_b64"].as_str()
+                .ok_or_else(|| InferenceError::Ipc(format!("missing depth_f32_b64 for {id}")))?;
+            let raw = B64.decode(depth_b64)
+                .map_err(|e| InferenceError::Ipc(format!("base64 depth for {id}: {e}")))?;
+            if raw.len() != depth_w * depth_h * 4 {
+                return Err(InferenceError::Ipc(format!(
+                    "depth size mismatch for {id}: got {} want {}",
+                    raw.len(), depth_w * depth_h * 4
+                )));
+            }
+            let depth: Vec<f32> = raw.chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect();
+
+            out.push((id, enh_rgb, enh_w, enh_h, depth, depth_w, depth_h));
+        }
         Ok(out)
     }
 
@@ -707,6 +799,19 @@ fn inflate_zlib(data: &[u8]) -> Result<Vec<u8>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn raune_depth_batch_item_fields_compile() {
+        let item = RauneDepthBatchItem {
+            id: "kf0000".to_string(),
+            pixels: vec![0u8; 60 * 80 * 3],
+            width: 80,
+            height: 60,
+            raune_max_size: 80,
+            depth_max_size: 56,
+        };
+        assert_eq!(item.id, "kf0000");
+    }
 
     #[test]
     fn upscale_depth_identity() {

--- a/crates/dorea-video/src/inference_subprocess.rs
+++ b/crates/dorea-video/src/inference_subprocess.rs
@@ -429,15 +429,15 @@ impl InferenceServer {
 
         if v["type"].as_str() == Some("error") {
             return Err(InferenceError::ServerError(
-                v["message"].as_str().unwrap_or("unknown").to_string(),
+                v["message"].as_str().unwrap_or("unknown error").to_string(),
             ));
         }
         if v["type"].as_str() != Some("raune_depth_batch_result") {
-            return Err(InferenceError::Ipc(format!("unexpected type: {resp}")));
+            return Err(InferenceError::Ipc(format!("unexpected response type: {resp}")));
         }
 
         let results = v["results"].as_array()
-            .ok_or_else(|| InferenceError::Ipc("missing results array".to_string()))?;
+            .ok_or_else(|| InferenceError::Ipc("missing results array in raune_depth_batch_result".to_string()))?;
 
         let mut out = Vec::with_capacity(results.len());
         for r in results {
@@ -451,6 +451,12 @@ impl InferenceServer {
             let enh_png = B64.decode(enh_b64)
                 .map_err(|e| InferenceError::Ipc(format!("base64 enh for {id}: {e}")))?;
             let enh_rgb = decode_png_bytes(&enh_png)?;
+            if enh_rgb.len() != enh_w * enh_h * 3 {
+                return Err(InferenceError::Ipc(format!(
+                    "enhanced image size mismatch for {id}: got {} want {}",
+                    enh_rgb.len(), enh_w * enh_h * 3
+                )));
+            }
 
             // Depth map (raw f32 LE)
             let depth_w = r["depth_width"].as_u64().unwrap_or(0) as usize;

--- a/python/dorea_inference/depth_anything.py
+++ b/python/dorea_inference/depth_anything.py
@@ -212,11 +212,14 @@ class DepthAnythingInference:
         Returns list of (H_d, W_d) float32 depth maps normalized to [0, 1].
         The resize and re-normalisation happen on-device — no dtoh between models.
         """
-        if enhanced.device != self.device:
+        if enhanced.device.type != self.device.type or (enhanced.device.index or 0) != (self.device.index or 0):
             raise ValueError(
                 f"infer_batch_from_tensors: enhanced tensor is on {enhanced.device} "
                 f"but model is on {self.device}. Caller must keep tensors on the same device."
             )
+
+        if enhanced.numel() == 0:
+            return []
 
         import torch
         import torch.nn.functional as F

--- a/python/dorea_inference/depth_anything.py
+++ b/python/dorea_inference/depth_anything.py
@@ -143,7 +143,11 @@ class DepthAnythingInference:
             arr = (arr - self._MEAN) / self._STD
             arrays.append(torch.from_numpy(arr).permute(2, 0, 1))
 
-        batch = torch.stack(arrays).to(self.device)  # (N, 3, H, W)
+        batch = torch.stack(arrays)
+        if self.device.type == "cuda":
+            batch = batch.pin_memory().to(self.device, non_blocking=True)
+        else:
+            batch = batch.to(self.device)
 
         with torch.no_grad():
             outputs = self.model(pixel_values=batch)
@@ -192,3 +196,52 @@ class DepthAnythingInference:
             depth = (depth - d_min) / (d_max - d_min)
 
         return depth.to(torch.float32).contiguous()
+
+    def infer_batch_from_tensors(
+        self,
+        enhanced: "torch.Tensor",
+        depth_max_size: int = 518,
+    ) -> "list[np.ndarray]":
+        """Run depth estimation on a batch of RAUNE-output GPU tensors.
+
+        Args:
+            enhanced: (N, 3, H_r, W_r) float32 in [0, 1], on self.device.
+                      This is the direct output of RauneNetInference.infer_batch_gpu().
+            depth_max_size: max long-edge for depth model (default 518).
+
+        Returns list of (H_d, W_d) float32 depth maps normalized to [0, 1].
+        The resize and re-normalisation happen on-device — no dtoh between models.
+        """
+        import torch
+        import torch.nn.functional as F
+
+        N, _, H_r, W_r = enhanced.shape
+
+        # GPU resize: keep aspect, snap to multiples of _PATCH_SIZE
+        scale = depth_max_size / max(H_r, W_r)
+        H_d = max(_PATCH_SIZE, int(H_r * scale) // _PATCH_SIZE * _PATCH_SIZE)
+        W_d = max(_PATCH_SIZE, int(W_r * scale) // _PATCH_SIZE * _PATCH_SIZE)
+
+        resized = F.interpolate(
+            enhanced, size=(H_d, W_d), mode="bilinear", align_corners=False
+        )  # (N, 3, H_d, W_d) in [0, 1]
+
+        # Re-normalise [0,1] → ImageNet stats Depth Anything expects
+        mean = torch.tensor(self._MEAN, dtype=torch.float32, device=enhanced.device).view(1, 3, 1, 1)
+        std  = torch.tensor(self._STD,  dtype=torch.float32, device=enhanced.device).view(1, 3, 1, 1)
+        depth_input = (resized - mean) / std  # (N, 3, H_d, W_d)
+
+        with torch.no_grad():
+            outputs = self.model(pixel_values=depth_input)
+
+        depths_raw = outputs.predicted_depth.cpu().numpy()  # (N, H_d, W_d)
+
+        result = []
+        for i in range(N):
+            d = depths_raw[i]
+            d_min, d_max = float(d.min()), float(d.max())
+            if d_max - d_min < 1e-6:
+                result.append(np.zeros_like(d, dtype=np.float32))
+            else:
+                result.append(((d - d_min) / (d_max - d_min)).astype(np.float32))
+        return result

--- a/python/dorea_inference/depth_anything.py
+++ b/python/dorea_inference/depth_anything.py
@@ -212,13 +212,19 @@ class DepthAnythingInference:
         Returns list of (H_d, W_d) float32 depth maps normalized to [0, 1].
         The resize and re-normalisation happen on-device — no dtoh between models.
         """
+        if enhanced.device != self.device:
+            raise ValueError(
+                f"infer_batch_from_tensors: enhanced tensor is on {enhanced.device} "
+                f"but model is on {self.device}. Caller must keep tensors on the same device."
+            )
+
         import torch
         import torch.nn.functional as F
 
         N, _, H_r, W_r = enhanced.shape
 
         # GPU resize: keep aspect, snap to multiples of _PATCH_SIZE
-        scale = depth_max_size / max(H_r, W_r)
+        scale = min(depth_max_size / max(H_r, W_r), 1.0)
         H_d = max(_PATCH_SIZE, int(H_r * scale) // _PATCH_SIZE * _PATCH_SIZE)
         W_d = max(_PATCH_SIZE, int(W_r * scale) // _PATCH_SIZE * _PATCH_SIZE)
 

--- a/python/dorea_inference/protocol.py
+++ b/python/dorea_inference/protocol.py
@@ -123,6 +123,21 @@ class DepthBatchResult:
 
 
 @dataclass
+class RauneDepthBatchResult:
+    """Fused RAUNE+depth batch response.
+
+    Each result dict contains:
+      id, image_b64 (PNG, enhanced frame), enhanced_width, enhanced_height,
+      depth_f32_b64, depth_width, depth_height, type="depth_result"
+    """
+    results: list
+    type: str = "raune_depth_batch_result"
+
+    def to_dict(self) -> dict:
+        return {"type": self.type, "results": self.results}
+
+
+@dataclass
 class ErrorResponse:
     id: Optional[str]
     message: str

--- a/python/dorea_inference/protocol.py
+++ b/python/dorea_inference/protocol.py
@@ -128,7 +128,7 @@ class RauneDepthBatchResult:
 
     Each result dict contains:
       id, image_b64 (PNG, enhanced frame), enhanced_width, enhanced_height,
-      depth_f32_b64, depth_width, depth_height, type="depth_result"
+      depth_f32_b64, depth_width, depth_height
     """
     results: list
     type: str = "raune_depth_batch_result"

--- a/python/dorea_inference/raune_net.py
+++ b/python/dorea_inference/raune_net.py
@@ -133,3 +133,98 @@ class RauneNetInference:
         result = (out.permute(1, 2, 0) * 255).to(torch.uint8).contiguous()
 
         return result  # stays on device
+
+    def infer_batch(self, imgs: "list[np.ndarray]", max_size: int = 1024) -> "list[np.ndarray]":
+        """Run RAUNE-Net on a batch of uint8 HxWx3 RGB images.
+
+        All images must resize to the same dims (guaranteed for frames from one video).
+        Falls back to sequential infer() if post-resize dims differ.
+        Returns list of uint8 HxWx3 arrays.
+        """
+        if not imgs:
+            return []
+
+        import torch
+        import torchvision.transforms as transforms
+        from PIL import Image as _Image
+
+        normalize = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+        tensors = []
+        wh_set = set()
+        for img in imgs:
+            r, tw, th = _resize_maintain_aspect(_Image.fromarray(img), max_size)
+            wh_set.add((tw, th))
+            tensors.append(normalize(transforms.ToTensor()(r)))
+
+        if len(wh_set) > 1:
+            import sys
+            print(
+                f"[dorea_inference] WARNING: infer_batch(raune): mixed post-resize dims "
+                f"{wh_set}; falling back to sequential",
+                file=sys.stderr,
+            )
+            return [self.infer(img, max_size) for img in imgs]
+
+        batch = torch.stack(tensors)  # (N, 3, H, W)
+        if self.device.type == "cuda":
+            batch = batch.pin_memory().to(self.device, non_blocking=True)
+        else:
+            batch = batch.to(self.device)
+
+        with torch.no_grad():
+            out = self.model(batch)  # (N, 3, H, W) in [-1, 1]
+
+        out = ((out + 1.0) / 2.0).clamp(0.0, 1.0)
+        out_np = out.cpu().numpy()  # (N, 3, H, W) float32
+        return [(out_np[i].transpose(1, 2, 0) * 255).astype(np.uint8) for i in range(len(imgs))]
+
+    def infer_batch_gpu(self, imgs: "list[np.ndarray]", max_size: int = 1024) -> "tuple[torch.Tensor, int, int]":
+        """Run RAUNE-Net batch, returning enhanced tensors on device (no dtoh).
+
+        Returns (batch_tensor, out_w, out_h) where batch_tensor is (N, 3, H, W)
+        float32 in [0, 1], still on self.device. Caller must not let it be GC'd.
+        Falls back to stacking infer() results if dims differ.
+        """
+        if not imgs:
+            import torch
+            return torch.zeros(0, 3, 1, 1, device=self.device), 0, 0
+
+        import torch
+        import torchvision.transforms as transforms
+        from PIL import Image as _Image
+
+        normalize = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+        tensors = []
+        wh_set = set()
+        out_w, out_h = 0, 0
+        for img in imgs:
+            r, tw, th = _resize_maintain_aspect(_Image.fromarray(img), max_size)
+            wh_set.add((tw, th))
+            out_w, out_h = tw, th
+            tensors.append(normalize(transforms.ToTensor()(r)))
+
+        if len(wh_set) > 1:
+            # Different sizes: run sequentially, collect results as GPU tensors
+            results = []
+            for img in imgs:
+                r, tw, th = _resize_maintain_aspect(_Image.fromarray(img), max_size)
+                t = normalize(transforms.ToTensor()(r)).unsqueeze(0).to(self.device)
+                with torch.no_grad():
+                    out = self.model(t)
+                out = ((out.squeeze(0) + 1.0) / 2.0).clamp(0.0, 1.0)
+                results.append(out)
+            stacked = torch.stack(results)
+            _, _, H, W = stacked.shape
+            return stacked, W, H
+
+        batch = torch.stack(tensors)
+        if self.device.type == "cuda":
+            batch = batch.pin_memory().to(self.device, non_blocking=True)
+        else:
+            batch = batch.to(self.device)
+
+        with torch.no_grad():
+            out = self.model(batch)  # (N, 3, H, W) in [-1, 1]
+
+        out = ((out + 1.0) / 2.0).clamp(0.0, 1.0)  # [0, 1], still on device
+        return out, out_w, out_h

--- a/python/dorea_inference/raune_net.py
+++ b/python/dorea_inference/raune_net.py
@@ -203,18 +203,13 @@ class RauneNetInference:
             tensors.append(normalize(transforms.ToTensor()(r)))
 
         if len(wh_set) > 1:
-            # Different sizes: run sequentially, collect results as GPU tensors
-            results = []
-            for img in imgs:
-                r, tw, th = _resize_maintain_aspect(_Image.fromarray(img), max_size)
-                t = normalize(transforms.ToTensor()(r)).unsqueeze(0).to(self.device)
-                with torch.no_grad():
-                    out = self.model(t)
-                out = ((out.squeeze(0) + 1.0) / 2.0).clamp(0.0, 1.0)
-                results.append(out)
-            stacked = torch.stack(results)
-            _, _, H, W = stacked.shape
-            return stacked, W, H
+            # Different post-resize dimensions: stacking is not possible.
+            # Raise a clear error — the fused GPU path requires uniform input dims.
+            raise ValueError(
+                f"infer_batch_gpu: images have different post-resize dimensions {wh_set}. "
+                "The GPU tensor path requires uniform dimensions. Use infer_batch() for "
+                "mixed-size inputs or ensure all images have the same source resolution."
+            )
 
         batch = torch.stack(tensors)
         if self.device.type == "cuda":

--- a/python/dorea_inference/raune_net.py
+++ b/python/dorea_inference/raune_net.py
@@ -183,15 +183,14 @@ class RauneNetInference:
 
         Returns (batch_tensor, out_w, out_h) where batch_tensor is (N, 3, H, W)
         float32 in [0, 1], still on self.device. Caller must not let it be GC'd.
-        Falls back to stacking infer() results if dims differ.
+        Falls back to sequential per-image forward passes (results stacked on device) if dims differ.
         """
-        if not imgs:
-            import torch
-            return torch.zeros(0, 3, 1, 1, device=self.device), 0, 0
-
         import torch
         import torchvision.transforms as transforms
         from PIL import Image as _Image
+
+        if not imgs:
+            return torch.zeros(0, 3, 0, 0, device=self.device), 0, 0
 
         normalize = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
         tensors = []

--- a/python/dorea_inference/server.py
+++ b/python/dorea_inference/server.py
@@ -29,6 +29,7 @@ from .protocol import (
     RauneResult,
     DepthResult,
     DepthBatchResult,
+    RauneDepthBatchResult,
     ErrorResponse,
     OkResponse,
     decode_png,
@@ -172,6 +173,47 @@ def main(argv: Optional[list] = None) -> None:
                     for item, depth in zip(items, depths)
                 ]
                 resp = DepthBatchResult(results=results)
+            elif req_type == "raune_depth_batch":
+                if raune_model is None:
+                    raise RuntimeError("RAUNE-Net not loaded — pass --raune-weights")
+                if depth_model is None:
+                    raise RuntimeError("Depth Anything not loaded — pass --depth-model")
+
+                items = req.get("items", [])
+                imgs = []
+                for item in items:
+                    fmt = item.get("format", "png")
+                    if fmt == "raw_rgb":
+                        imgs.append(decode_raw_rgb(item["image_b64"], int(item["width"]), int(item["height"])))
+                    else:
+                        imgs.append(decode_png(item["image_b64"]))
+
+                raune_max = int(items[0].get("raune_max_size", 1024)) if items else 1024
+                depth_max = int(items[0].get("depth_max_size", 518)) if items else 518
+
+                # RAUNE → enhanced tensors stay on GPU
+                enhanced_batch, enh_w, enh_h = raune_model.infer_batch_gpu(imgs, max_size=raune_max)
+
+                # Depth on enhanced tensors — no dtoh between models
+                depth_maps = depth_model.infer_batch_from_tensors(enhanced_batch, depth_max_size=depth_max)
+
+                # dtoh enhanced frames for output
+                enhanced_np = (
+                    enhanced_batch.permute(0, 2, 3, 1).cpu().numpy() * 255
+                ).astype("uint8")  # (N, H, W, 3)
+
+                results = []
+                for i, (item, depth) in enumerate(zip(items, depth_maps)):
+                    depth_result = DepthResult.from_array(item.get("id"), depth)
+                    results.append({
+                        "id": item.get("id"),
+                        "image_b64": encode_png(enhanced_np[i]),
+                        "enhanced_width": int(enh_w),
+                        "enhanced_height": int(enh_h),
+                        **{k: v for k, v in depth_result.to_dict().items()
+                           if k in ("depth_f32_b64", "depth_width", "depth_height", "type")},
+                    })
+                resp = RauneDepthBatchResult(results=results)
             elif req_type == "shutdown":
                 resp = OkResponse()
                 try:

--- a/python/dorea_inference/server.py
+++ b/python/dorea_inference/server.py
@@ -210,8 +210,9 @@ def main(argv: Optional[list] = None) -> None:
                         "image_b64": encode_png(enhanced_np[i]),
                         "enhanced_width": int(enh_w),
                         "enhanced_height": int(enh_h),
-                        **{k: v for k, v in depth_result.to_dict().items()
-                           if k in ("depth_f32_b64", "depth_width", "depth_height", "type")},
+                        "depth_f32_b64": depth_result.depth_f32_b64,
+                        "depth_width": depth_result.width,
+                        "depth_height": depth_result.height,
                     })
                 resp = RauneDepthBatchResult(results=results)
             elif req_type == "shutdown":

--- a/python/tests/test_infer_batch.py
+++ b/python/tests/test_infer_batch.py
@@ -1,0 +1,55 @@
+"""Tests for infer_batch methods — CPU mode, no GPU or real weights required."""
+import numpy as np
+import pytest
+import torch
+
+
+def _make_rgb(h: int, w: int) -> np.ndarray:
+    return np.random.default_rng(42).integers(0, 256, (h, w, 3), dtype=np.uint8)
+
+
+def _fake_raune_model():
+    """Identity RauneNetInference on CPU, no weights file needed."""
+    import types, sys
+    fake_mod = types.ModuleType("models")
+    fake_mod.raune_net = types.ModuleType("models.raune_net")
+
+    class _IdentityNet(torch.nn.Module):
+        def forward(self, x):
+            return x  # identity; output in same range as input ([-1,1] after normalize)
+
+    fake_mod.raune_net.RauneNet = lambda **_: _IdentityNet()
+    sys.modules.setdefault("models", fake_mod)
+    sys.modules.setdefault("models.raune_net", fake_mod.raune_net)
+
+    from dorea_inference.raune_net import RauneNetInference
+    m = RauneNetInference.__new__(RauneNetInference)
+    m.device = torch.device("cpu")
+    m.model = _IdentityNet()
+    m.model.eval()
+    return m
+
+
+class TestRauneInferBatch:
+    def test_returns_same_count(self):
+        model = _fake_raune_model()
+        imgs = [_make_rgb(60, 80) for _ in range(5)]
+        results = model.infer_batch(imgs, max_size=80)
+        assert len(results) == 5
+
+    def test_output_dtype_and_channels(self):
+        model = _fake_raune_model()
+        results = model.infer_batch([_make_rgb(60, 80)], max_size=80)
+        assert results[0].dtype == np.uint8
+        assert results[0].ndim == 3
+        assert results[0].shape[2] == 3
+
+    def test_empty_returns_empty(self):
+        model = _fake_raune_model()
+        assert model.infer_batch([], max_size=80) == []
+
+    def test_mixed_dims_falls_back_to_sequential(self):
+        model = _fake_raune_model()
+        imgs = [_make_rgb(60, 80), _make_rgb(40, 60)]  # different sizes
+        results = model.infer_batch(imgs, max_size=160)
+        assert len(results) == 2

--- a/python/tests/test_infer_batch.py
+++ b/python/tests/test_infer_batch.py
@@ -53,3 +53,48 @@ class TestRauneInferBatch:
         imgs = [_make_rgb(60, 80), _make_rgb(40, 60)]  # different sizes
         results = model.infer_batch(imgs, max_size=160)
         assert len(results) == 2
+
+
+class TestDepthInferBatchFromTensors:
+    def test_accepts_gpu_tensor_shape(self):
+        """infer_batch_from_tensors returns one depth map per input tensor."""
+        from dorea_inference.depth_anything import DepthAnythingInference
+
+        class _FakeDepthModel(torch.nn.Module):
+            class _Out:
+                def __init__(self, t): self.predicted_depth = t
+            def forward(self, pixel_values=None):
+                N, _, H, W = pixel_values.shape
+                return self._Out(pixel_values[:, 0, :, :])  # (N, H, W) dummy
+
+        model = DepthAnythingInference.__new__(DepthAnythingInference)
+        model.device = torch.device("cpu")
+        model.model = _FakeDepthModel()
+
+        # Simulate RAUNE output: (3, 3, H, W) float32 in [0, 1]
+        fake_enhanced = torch.rand(3, 3, 56, 84)  # 3 frames, not yet patch-aligned
+        depths = model.infer_batch_from_tensors(fake_enhanced, depth_max_size=56)
+        assert len(depths) == 3
+        assert all(isinstance(d, np.ndarray) for d in depths)
+        assert all(d.dtype == np.float32 for d in depths)
+
+    def test_output_dims_are_patch_aligned(self):
+        """Output depth map dimensions are multiples of 14."""
+        from dorea_inference.depth_anything import DepthAnythingInference
+
+        class _FakeDepthModel(torch.nn.Module):
+            class _Out:
+                def __init__(self, t): self.predicted_depth = t
+            def forward(self, pixel_values=None):
+                N, _, H, W = pixel_values.shape
+                return self._Out(pixel_values[:, 0, :, :])
+
+        model = DepthAnythingInference.__new__(DepthAnythingInference)
+        model.device = torch.device("cpu")
+        model.model = _FakeDepthModel()
+
+        fake_enhanced = torch.rand(1, 3, 100, 180)
+        depths = model.infer_batch_from_tensors(fake_enhanced, depth_max_size=98)
+        H, W = depths[0].shape
+        assert H % 14 == 0, f"height {H} not multiple of 14"
+        assert W % 14 == 0, f"width {W} not multiple of 14"

--- a/python/tests/test_infer_batch.py
+++ b/python/tests/test_infer_batch.py
@@ -98,3 +98,28 @@ class TestDepthInferBatchFromTensors:
         H, W = depths[0].shape
         assert H % 14 == 0, f"height {H} not multiple of 14"
         assert W % 14 == 0, f"width {W} not multiple of 14"
+
+
+class TestRauneDepthBatchProtocol:
+    def test_raune_depth_batch_result_roundtrip(self):
+        """RauneDepthBatchResult serialises/deserialises correctly."""
+        from dorea_inference.protocol import RauneDepthBatchResult, DepthResult, RauneResult, encode_png
+        import json
+
+        dummy_img = np.zeros((14, 14, 3), dtype=np.uint8)
+        dummy_depth = np.zeros((14, 14), dtype=np.float32)
+
+        item = {
+            "id": "kf0000",
+            "image_b64": encode_png(dummy_img),
+            "enhanced_width": 14,
+            "enhanced_height": 14,
+            **DepthResult.from_array("kf0000", dummy_depth).to_dict(),
+        }
+        resp = RauneDepthBatchResult(results=[item])
+        d = resp.to_dict()
+        assert d["type"] == "raune_depth_batch_result"
+        assert len(d["results"]) == 1
+        assert d["results"][0]["id"] == "kf0000"
+        # Round-trip through JSON
+        assert json.loads(json.dumps(d))["type"] == "raune_depth_batch_result"


### PR DESCRIPTION
Closes #47

## Summary

- Adds `RauneDepthBatchItem` and `run_raune_depth_batch` to `dorea-video` — single IPC call sends a batch of raw-RGB frames, RAUNE output stays on GPU, depth runs on the enhanced tensor with no dtoh between models
- Adds `infer_batch_gpu` to `RauneNetInference` — returns `(N,3,H,W)` float32 [0,1] on device
- Adds `infer_batch_from_tensors` to `DepthAnythingInference` — accepts RAUNE's on-device tensor, GPU-resizes, re-normalises with ImageNet stats, one batched forward pass
- Adds `raune_depth_batch` IPC handler to the Python server
- Rewrites `auto_calibrate` in `grade.rs` to use 3-phase fused inference (collect → fused batch → push to store), eliminating 4 IPC crossings per frame (110 → 7 round-trips for 55 frames)
- `FUSED_BATCH_SIZE=8` chosen for 6GB RTX 3060: RAUNE ~3GB + Depth ~1.5GB = ~4.5GB, 8 × 57MB GPU input leaves safe headroom

## Key fixes addressed during review

- **Device guard**: use `.type` and `.index or 0` comparison (not `device ==`) — `torch.device('cuda') != torch.device('cuda:0')` would always fire false negative
- **Empty batch**: `numel() == 0` guard before scale calc prevents ZeroDivisionError from `max(0,0)`
- **Mixed-dims fallback**: raises `ValueError` instead of crashing in `torch.stack` with heterogeneous shapes
- **Release assertion**: `anyhow::ensure!` instead of `debug_assert_eq!` (stripped in release builds)
- **Batch assembly**: explicit `depth_width`/`depth_height` keys in server result (whitelist approach silently dropped them)

## Test plan

- [x] 7 Python unit tests (`test_infer_batch.py`): batch count, dtype, empty input, mixed-dims fallback, GPU tensor shape, patch-alignment, protocol roundtrip — all pass
- [x] 14 dorea-video tests + 8 dorea-cli tests — all pass
- [x] `cargo check` clean
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)