### PR TITLE
feat: 10-bit pipeline — DJI D-Log M + Insta360 X5 I-Log support

### DIFF
--- a/crates/dorea-cli/src/config.rs
+++ b/crates/dorea-cli/src/config.rs
@@ -73,6 +73,10 @@ pub struct GradeDefaults {
     pub min_segment_keyframes: Option<usize>,
     /// Zone boundary smoothing window width; 1 = no smoothing (default: 3)
     pub zone_smoothing_window: Option<usize>,
+    /// Input encoding override (default: auto-detect from container/codec)
+    pub input_encoding: Option<String>,
+    /// Output codec (default: "h264" for 8-bit, "prores" for 10-bit)
+    pub output_codec: Option<String>,
 }
 
 /// Maxine VFX SDK defaults (used when Maxine is re-enabled).

--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use clap::Args;
 use anyhow::{Context, Result};
 
-use dorea_video::ffmpeg::{self, FrameEncoder};
+use dorea_video::ffmpeg::{self, FrameEncoder, InputEncoding, OutputCodec};
 use dorea_video::inference::{InferenceConfig, InferenceServer};
 
 use crate::pipeline::{self, PipelineConfig};
@@ -95,6 +95,14 @@ pub struct GradeArgs {
     /// (config: [maxine].upscale_factor, built-in default: 2)
     #[arg(long)]
     pub maxine_upscale_factor: Option<u32>,
+
+    /// Input encoding: dlog-m, ilog, srgb (default: auto-detect from container)
+    #[arg(long)]
+    pub input_encoding: Option<String>,
+
+    /// Output codec: prores, hevc10, h264 (default: auto for source bit depth)
+    #[arg(long)]
+    pub output_codec: Option<String>,
 }
 
 pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
@@ -135,13 +143,6 @@ pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
         anyhow::bail!("--depth-max-interval must be >= 1");
     }
 
-    let output = args.output.clone().unwrap_or_else(|| {
-        let stem = args.input.file_stem().unwrap_or_default().to_string_lossy();
-        args.input.with_file_name(format!("{stem}_graded.mp4"))
-    });
-
-    log::info!("Grading: {} → {}", args.input.display(), output.display());
-
     // Probe input
     let info = ffmpeg::probe(&args.input)
         .context("ffprobe failed — is ffmpeg installed?")?;
@@ -150,10 +151,41 @@ pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
         info.width, info.height, info.fps, info.duration_secs, info.frame_count
     );
 
+    // Resolve input encoding: CLI flag → config → auto-detect
+    let input_encoding = args.input_encoding.as_deref()
+        .or(cfg.grade.input_encoding.as_deref())
+        .map(|s| s.parse::<InputEncoding>().map_err(|e| anyhow::anyhow!("invalid --input-encoding: {e}")))
+        .transpose()?
+        .unwrap_or_else(|| InputEncoding::auto_detect(&info, &args.input));
+
+    // Resolve output codec: CLI flag → config → auto based on input encoding
+    let output_codec = args.output_codec.as_deref()
+        .or(cfg.grade.output_codec.as_deref())
+        .map(|s| s.parse::<OutputCodec>().map_err(|e| anyhow::anyhow!("invalid --output-codec: {e}")))
+        .transpose()?
+        .unwrap_or_else(|| {
+            if input_encoding.is_10bit() { OutputCodec::ProRes } else { OutputCodec::H264 }
+        });
+
+    log::info!("Encoding: input={input_encoding}, output={output_codec}, 10-bit={}", output_codec.is_10bit());
+
+    let output = args.output.clone().unwrap_or_else(|| {
+        let stem = args.input.file_stem().unwrap_or_default().to_string_lossy();
+        let ext = if output_codec == OutputCodec::ProRes { "mov" } else { "mp4" };
+        args.input.with_file_name(format!("{stem}_graded.{ext}"))
+    });
+
+    log::info!("Grading: {} → {}", args.input.display(), output.display());
+
     // Open encoder first — validate output path before doing expensive calibration.
     let audio_src = if info.has_audio { Some(args.input.as_path()) } else { None };
-    let encoder = FrameEncoder::new(&output, info.width, info.height, info.fps, audio_src)
-        .context("failed to spawn ffmpeg encoder")?;
+    let encoder = if output_codec.is_10bit() {
+        FrameEncoder::new_10bit(&output, info.width, info.height, info.fps, output_codec, audio_src)
+            .context("failed to spawn 10-bit ffmpeg encoder")?
+    } else {
+        FrameEncoder::new(&output, info.width, info.height, info.fps, audio_src)
+            .context("failed to spawn ffmpeg encoder")?
+    };
 
     let inf_cfg = build_inference_config(
         &python, raune_weights.as_deref(), raune_models_dir.as_deref(),
@@ -177,6 +209,8 @@ pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
         maxine_upscale_factor,
         interp_enabled: !args.no_depth_interp,
         maxine_in_fused_batch: false, // Maxine disabled — SDK not available in devcontainer
+        input_encoding,
+        output_codec,
     };
 
     // -----------------------------------------------------------------------
@@ -289,7 +323,7 @@ mod tests {
     fn build_inference_config_defaults() {
         let python = PathBuf::from("/opt/dorea-venv/bin/python");
         let cfg = build_inference_config(&python, None, None, None, None, 2);
-        assert!(cfg.maxine, "Maxine should be enabled for fused batch upscaling");
+        assert!(!cfg.maxine, "Maxine should be disabled — SDK not available in devcontainer");
         assert!(!cfg.skip_raune, "RAUNE should not be skipped in config");
         assert!(!cfg.skip_depth, "depth should not be skipped in config");
     }

--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -327,4 +327,38 @@ mod tests {
         assert!(!cfg.skip_raune, "RAUNE should not be skipped in config");
         assert!(!cfg.skip_depth, "depth should not be skipped in config");
     }
+
+    #[test]
+    fn default_encoding_for_8bit_h264() {
+        use dorea_video::ffmpeg::{InputEncoding, OutputCodec, VideoInfo};
+        let info = VideoInfo {
+            width: 1920, height: 1080, fps: 30.0, duration_secs: 10.0,
+            frame_count: 300, has_audio: true,
+            codec_name: "h264".to_string(),
+            pix_fmt: "yuv420p".to_string(),
+            bits_per_component: 8,
+        };
+        let enc = InputEncoding::auto_detect(&info, std::path::Path::new("clip.mp4"));
+        assert_eq!(enc, InputEncoding::Srgb);
+        assert!(!enc.is_10bit());
+        let codec = if enc.is_10bit() { OutputCodec::ProRes } else { OutputCodec::H264 };
+        assert_eq!(codec, OutputCodec::H264);
+    }
+
+    #[test]
+    fn default_encoding_for_10bit_hevc() {
+        use dorea_video::ffmpeg::{InputEncoding, OutputCodec, VideoInfo};
+        let info = VideoInfo {
+            width: 3840, height: 2160, fps: 29.97, duration_secs: 3.0,
+            frame_count: 90, has_audio: true,
+            codec_name: "hevc".to_string(),
+            pix_fmt: "yuv420p10le".to_string(),
+            bits_per_component: 10,
+        };
+        let enc = InputEncoding::auto_detect(&info, std::path::Path::new("clip.mp4"));
+        assert_eq!(enc, InputEncoding::DLogM);
+        assert!(enc.is_10bit());
+        let codec = if enc.is_10bit() { OutputCodec::ProRes } else { OutputCodec::H264 };
+        assert_eq!(codec, OutputCodec::ProRes);
+    }
 }

--- a/crates/dorea-cli/src/lib.rs
+++ b/crates/dorea-cli/src/lib.rs
@@ -5,3 +5,4 @@ pub mod grade;
 pub mod optical_flow;
 pub mod pipeline;
 pub mod preview;
+pub mod probe;

--- a/crates/dorea-cli/src/main.rs
+++ b/crates/dorea-cli/src/main.rs
@@ -16,6 +16,8 @@ enum Command {
     Grade(dorea_cli::grade::GradeArgs),
     /// Generate a before/after contact sheet (5-10 frames)
     Preview(dorea_cli::preview::PreviewArgs),
+    /// Detect container, codec, bit depth, and suggest flags
+    Probe(dorea_cli::probe::ProbeArgs),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -27,6 +29,7 @@ fn main() -> anyhow::Result<()> {
         Command::Calibrate(a) => a.verbose,
         Command::Grade(a) => a.verbose,
         Command::Preview(a) => a.verbose,
+        Command::Probe(_) => false,
     };
 
     env_logger::Builder::from_env(env_logger::Env::default())
@@ -43,5 +46,6 @@ fn main() -> anyhow::Result<()> {
         Command::Calibrate(args) => dorea_cli::calibrate::run(args, &config),
         Command::Grade(args) => dorea_cli::grade::run(args, &config),
         Command::Preview(args) => dorea_cli::preview::run(args, &config),
+        Command::Probe(args) => dorea_cli::probe::run(args),
     }
 }

--- a/crates/dorea-cli/src/pipeline/grading.rs
+++ b/crates/dorea-cli/src/pipeline/grading.rs
@@ -6,11 +6,14 @@
 //!   Thread 3 (encoder):  channel_b → ffmpeg encoder write
 //!
 //! The AdaptiveGrader is !Send — it stays on the main thread (Thread 2).
+//!
+//! Two variants exist:
+//!   - `run_grading_stage_8bit`: Frame (u8) decode → grade_frame_blended → write_frame (u8)
+//!   - `run_grading_stage_16bit`: Frame16 (u16) decode → grade_frame_blended_16 → write_frame_16 (u16)
 
 use anyhow::{Context, Result};
 
 use dorea_video::ffmpeg::{self, Frame, FrameEncoder, VideoInfo};
-use dorea_video::inference::InferenceServer;
 
 #[cfg(feature = "cuda")]
 use dorea_gpu::AdaptiveGrader;
@@ -29,11 +32,22 @@ pub fn lerp_depth(a: &[f32], b: &[f32], t: f32) -> Vec<f32> {
         .collect()
 }
 
-/// Run the grading stage as a 3-thread pipeline: decode | grade | encode.
-///
-/// The GPU thread (main) owns the AdaptiveGrader (!Send). Decoder and encoder
-/// run on spawned threads connected by bounded crossbeam channels.
+/// Run the grading stage — dispatches to 8-bit or 16-bit variant based on output codec.
 pub fn run_grading_stage(
+    cfg: &PipelineConfig,
+    info: &VideoInfo,
+    encoder: FrameEncoder,
+    cal_out: CalibrationStageOutput,
+) -> Result<u64> {
+    if cfg.output_codec.is_10bit() {
+        run_grading_stage_16bit(cfg, info, encoder, cal_out)
+    } else {
+        run_grading_stage_8bit(cfg, info, encoder, cal_out)
+    }
+}
+
+/// 8-bit grading pipeline: Frame (u8) → grade_frame_blended → write_frame (u8).
+fn run_grading_stage_8bit(
     cfg: &PipelineConfig,
     info: &VideoInfo,
     encoder: FrameEncoder,
@@ -45,7 +59,7 @@ pub fn run_grading_stage(
         kf_to_segment,
         keyframe_depths,
         kf_index_list,
-        store_len,
+        store_len: _,
         keyframe_masks,
     } = cal_out;
 
@@ -260,7 +274,7 @@ pub fn run_grading_stage(
                     let seg_idx = kf_to_segment.get(kf_cursor).copied().unwrap_or(0);
                     let cal = &segment_calibrations[seg_idx];
                     let calibration = Calibration::new(
-                        cal.depth_luts.clone(), cal.hsl_corrections.clone(), store_len,
+                        cal.depth_luts.clone(), cal.hsl_corrections.clone(), 0,
                     );
                     grade_frame(&frame.pixels, &depth, frame.width, frame.height, &calibration, &params)
                         .map_err(|e| anyhow::anyhow!("Grading failed for frame {fi}: {e}"))?
@@ -284,6 +298,264 @@ pub fn run_grading_stage(
             .map_err(|_| anyhow::anyhow!("encoder thread panicked"))?;
 
         // Propagate GPU error first (root cause), then thread errors.
+        gpu_result.context("GPU grading failed")?;
+        decoder_result.context("decoder thread failed")?;
+        encoder_result
+    })
+}
+
+/// 16-bit grading pipeline: Frame16 (u16) → grade_frame_blended_16 → write_frame_16 (u16).
+///
+/// Same 3-thread structure as the 8-bit variant but uses `decode_frames_16bit`,
+/// `grade_frame_blended_16`, and `write_frame_16` to preserve 10-bit precision
+/// throughout the pipeline.
+fn run_grading_stage_16bit(
+    cfg: &PipelineConfig,
+    info: &VideoInfo,
+    encoder: FrameEncoder,
+    cal_out: CalibrationStageOutput,
+) -> Result<u64> {
+    use dorea_video::ffmpeg::Frame16;
+
+    let CalibrationStageOutput {
+        segment_calibrations,
+        smoothed_kf_zones,
+        kf_to_segment,
+        keyframe_depths,
+        kf_index_list,
+        store_len: _,
+        keyframe_masks,
+    } = cal_out;
+
+    let params = cfg.grade_params();
+
+    // Initialize adaptive CUDA grader on the main thread (Thread 2 — GPU owner).
+    #[cfg(feature = "cuda")]
+    let mut adaptive_grader = {
+        let seg0 = &segment_calibrations[0];
+        let base_flat: Vec<f32> = seg0.depth_luts.luts.iter()
+            .flat_map(|lut| lut.data.iter().copied())
+            .collect();
+        let base_bounds = &seg0.depth_luts.zone_boundaries;
+        let hsl = &seg0.hsl_corrections;
+        let h_offsets: Vec<f32> = hsl.0.iter().map(|q| q.h_offset).collect();
+        let s_ratios:  Vec<f32> = hsl.0.iter().map(|q| q.s_ratio).collect();
+        let v_offsets: Vec<f32> = hsl.0.iter().map(|q| q.v_offset).collect();
+        let weights:   Vec<f32> = hsl.0.iter().map(|q| q.weight).collect();
+        let lut_size = seg0.depth_luts.luts[0].size;
+
+        AdaptiveGrader::new(
+            &base_flat, base_bounds, cfg.base_lut_zones,
+            (&h_offsets, &s_ratios, &v_offsets, &weights),
+            &params, lut_size, cfg.depth_zones,
+        ).context("AdaptiveGrader init failed")?
+    };
+
+    #[cfg(feature = "cuda")]
+    {
+        adaptive_grader.prepare_keyframe(&smoothed_kf_zones[0])
+            .context("prepare initial keyframe texture failed")?;
+        adaptive_grader.swap_textures();
+        if smoothed_kf_zones.len() > 1 {
+            adaptive_grader.prepare_keyframe(&smoothed_kf_zones[1])
+                .context("prepare second keyframe texture failed")?;
+        }
+        log::info!(
+            "Adaptive CUDA grader initialized for 16-bit ({} base zones, {} runtime zones)",
+            cfg.base_lut_zones, cfg.depth_zones,
+        );
+    }
+
+    // Create bounded channels for the 3-thread pipeline.
+    // Decoder→GPU carries Frame16 (u16 pixels). GPU→encoder carries Vec<u16>.
+    let (decoded_tx, decoded_rx) = crossbeam_channel::bounded::<Frame16>(CHANNEL_CAPACITY);
+    let (graded_tx, graded_rx) = crossbeam_channel::bounded::<Vec<u16>>(CHANNEL_CAPACITY);
+
+    let total_frames = info.frame_count;
+
+    std::thread::scope(|s| -> Result<u64> {
+        // ---------------------------------------------------------------
+        // Thread 1: Decoder — reads 16-bit frames from ffmpeg
+        // ---------------------------------------------------------------
+        let decoder_handle = s.spawn(|| -> Result<()> {
+            let frames = ffmpeg::decode_frames_16bit(&cfg.input, info)
+                .context("failed to spawn ffmpeg full-res 16-bit decoder")?;
+            for frame_result in frames {
+                let frame = frame_result.context("16-bit frame decode error")?;
+                if decoded_tx.send(frame).is_err() {
+                    break;
+                }
+            }
+            drop(decoded_tx);
+            Ok(())
+        });
+
+        // ---------------------------------------------------------------
+        // Thread 3: Encoder — receives graded u16 frames, writes via write_frame_16
+        // ---------------------------------------------------------------
+        let encoder_handle = s.spawn(move || -> Result<u64> {
+            let mut encoder = encoder;
+            let mut frame_count = 0u64;
+            for graded in graded_rx {
+                encoder.write_frame_16(&graded).context("16-bit encoder write failed")?;
+                frame_count += 1;
+                if frame_count % 100 == 0 {
+                    let pct = frame_count as f64 / total_frames.max(1) as f64 * 100.0;
+                    log::info!("Progress: {frame_count}/{} frames ({:.1}%)", total_frames, pct);
+                }
+            }
+            encoder.finish().context("ffmpeg encoder failed to finalize")?;
+            Ok(frame_count)
+        });
+
+        // ---------------------------------------------------------------
+        // GPU thread (main) — depth interp + 16-bit grade
+        // ---------------------------------------------------------------
+        let gpu_result: Result<()> = (|| {
+            let mut kf_cursor = 0usize;
+            #[cfg(feature = "cuda")]
+            let mut current_segment = kf_to_segment.first().copied().unwrap_or(0);
+
+            for frame in decoded_rx {
+                let fi = frame.index;
+
+                // Advance cursor to most recent keyframe ≤ fi
+                while kf_cursor + 1 < kf_index_list.len() && kf_index_list[kf_cursor + 1].0 <= fi {
+                    kf_cursor += 1;
+
+                    #[cfg(feature = "cuda")]
+                    {
+                        let new_seg = kf_to_segment[kf_cursor];
+                        if new_seg != current_segment {
+                            let seg_cal = &segment_calibrations[new_seg];
+                            let base_flat: Vec<f32> = seg_cal.depth_luts.luts.iter()
+                                .flat_map(|lut| lut.data.iter().copied())
+                                .collect();
+                            let base_bounds = &seg_cal.depth_luts.zone_boundaries;
+                            let hsl = &seg_cal.hsl_corrections;
+                            let h_offsets: Vec<f32> = hsl.0.iter().map(|q| q.h_offset).collect();
+                            let s_ratios:  Vec<f32> = hsl.0.iter().map(|q| q.s_ratio).collect();
+                            let v_offsets: Vec<f32> = hsl.0.iter().map(|q| q.v_offset).collect();
+                            let weights:   Vec<f32> = hsl.0.iter().map(|q| q.weight).collect();
+                            adaptive_grader.load_segment(
+                                &base_flat, base_bounds,
+                                (&h_offsets, &s_ratios, &v_offsets, &weights),
+                            ).context("load_segment failed")?;
+                            adaptive_grader.prepare_keyframe(&smoothed_kf_zones[kf_cursor])
+                                .context("prepare_keyframe at segment boundary failed")?;
+                            current_segment = new_seg;
+                            log::info!("Segment switch to {new_seg} at keyframe {kf_cursor}");
+                        }
+
+                        adaptive_grader.swap_textures();
+
+                        if kf_cursor + 1 < smoothed_kf_zones.len() {
+                            adaptive_grader.prepare_keyframe(&smoothed_kf_zones[kf_cursor + 1])
+                                .context("prepare_keyframe failed")?;
+                        }
+                    }
+                }
+
+                let (prev_kf_idx, _) = kf_index_list[kf_cursor];
+                let (prev_depth_proxy, dpw, dph) = keyframe_depths
+                    .get(&prev_kf_idx)
+                    .expect("prev keyframe depth missing — logic error");
+                let (dpw, dph) = (*dpw, *dph);
+
+                let depth_proxy = if fi == prev_kf_idx {
+                    prev_depth_proxy.clone()
+                } else if let Some(&(next_kf_idx, scene_cut_before_next)) = kf_index_list.get(kf_cursor + 1) {
+                    if scene_cut_before_next {
+                        prev_depth_proxy.clone()
+                    } else {
+                        let (next_depth_proxy, _, _) = keyframe_depths
+                            .get(&next_kf_idx)
+                            .expect("next keyframe depth missing — logic error");
+                        let t = (fi - prev_kf_idx) as f32 / (next_kf_idx - prev_kf_idx) as f32;
+                        lerp_depth(prev_depth_proxy, next_depth_proxy, t)
+                    }
+                } else {
+                    prev_depth_proxy.clone()
+                };
+
+                let depth = depth_proxy;
+
+                let blend_t = if fi == prev_kf_idx {
+                    0.0_f32
+                } else if let Some(&(next_kf_idx, scene_cut)) = kf_index_list.get(kf_cursor + 1) {
+                    if scene_cut { 0.0 } else {
+                        ((fi - prev_kf_idx) as f32 / (next_kf_idx - prev_kf_idx) as f32).clamp(0.0, 1.0)
+                    }
+                } else {
+                    0.0
+                };
+
+                #[cfg(feature = "cuda")]
+                // Look up the nearest keyframe's class mask for diver detection.
+                let (class_mask_slice, mask_w, mask_h, diver_depth) = match keyframe_masks.get(&prev_kf_idx) {
+                    Some((mask, mw, mh)) => {
+                        let diver_d = {
+                            let mut diver_depths: Vec<f32> = Vec::new();
+                            for (mi, &class_id) in mask.iter().enumerate() {
+                                if class_id > 0 {
+                                    let mx = mi % mw;
+                                    let my = mi / mw;
+                                    let dx = mx as f32 * (dpw as f32 - 1.0) / (*mw as f32 - 1.0).max(1.0);
+                                    let dy = my as f32 * (dph as f32 - 1.0) / (*mh as f32 - 1.0).max(1.0);
+                                    let di = (dy as usize).min(dph - 1) * dpw + (dx as usize).min(dpw - 1);
+                                    if di < depth.len() {
+                                        diver_depths.push(depth[di]);
+                                    }
+                                }
+                            }
+                            if diver_depths.is_empty() {
+                                0.5
+                            } else {
+                                diver_depths.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                                diver_depths[diver_depths.len() / 2]
+                            }
+                        };
+                        (Some(mask.as_slice()), *mw, *mh, diver_d)
+                    }
+                    None => (None, 0, 0, 0.5),
+                };
+
+                // 16-bit grading — uses grade_frame_blended_16 with u16 pixel data.
+                let graded = adaptive_grader.grade_frame_blended_16(
+                    &frame.pixels, &depth, frame.width, frame.height, dpw, dph, blend_t,
+                    class_mask_slice, mask_w, mask_h, diver_depth,
+                ).map_err(|e| anyhow::anyhow!("16-bit grading failed for frame {fi}: {e}"))?;
+
+                #[cfg(not(feature = "cuda"))]
+                let graded = {
+                    use dorea_cal::Calibration;
+                    use dorea_gpu::grade_frame_with_adaptive_grader_16;
+                    let seg_idx = kf_to_segment.get(kf_cursor).copied().unwrap_or(0);
+                    let cal = &segment_calibrations[seg_idx];
+                    let calibration = Calibration::new(
+                        cal.depth_luts.clone(), cal.hsl_corrections.clone(), 0,
+                    );
+                    grade_frame_with_adaptive_grader_16(
+                        &frame.pixels, &depth, frame.width, frame.height, &calibration, &params,
+                    ).map_err(|e| anyhow::anyhow!("16-bit grading failed for frame {fi}: {e}"))?
+                };
+
+                if graded_tx.send(graded).is_err() {
+                    break;
+                }
+            }
+            Ok(())
+        })();
+
+        // Signal encoder that no more frames are coming
+        drop(graded_tx);
+
+        // Always join threads — even when GPU errored — to collect all errors.
+        let decoder_result = decoder_handle.join()
+            .map_err(|_| anyhow::anyhow!("decoder thread panicked"))?;
+        let encoder_result = encoder_handle.join()
+            .map_err(|_| anyhow::anyhow!("encoder thread panicked"))?;
+
         gpu_result.context("GPU grading failed")?;
         decoder_result.context("decoder thread failed")?;
         encoder_result

--- a/crates/dorea-cli/src/pipeline/grading.rs
+++ b/crates/dorea-cli/src/pipeline/grading.rs
@@ -527,18 +527,11 @@ fn run_grading_stage_16bit(
                 ).map_err(|e| anyhow::anyhow!("16-bit grading failed for frame {fi}: {e}"))?;
 
                 #[cfg(not(feature = "cuda"))]
-                let graded = {
-                    use dorea_cal::Calibration;
-                    use dorea_gpu::grade_frame_with_adaptive_grader_16;
-                    let seg_idx = kf_to_segment.get(kf_cursor).copied().unwrap_or(0);
-                    let cal = &segment_calibrations[seg_idx];
-                    let calibration = Calibration::new(
-                        cal.depth_luts.clone(), cal.hsl_corrections.clone(), 0,
+                {
+                    anyhow::bail!(
+                        "10-bit grading requires CUDA. Build with --features cuda or use --output-codec h264 for 8-bit CPU grading."
                     );
-                    grade_frame_with_adaptive_grader_16(
-                        &frame.pixels, &depth, frame.width, frame.height, &calibration, &params,
-                    ).map_err(|e| anyhow::anyhow!("16-bit grading failed for frame {fi}: {e}"))?
-                };
+                }
 
                 if graded_tx.send(graded).is_err() {
                     break;

--- a/crates/dorea-cli/src/pipeline/mod.rs
+++ b/crates/dorea-cli/src/pipeline/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use dorea_gpu::GradeParams;
+use dorea_video::ffmpeg::{InputEncoding, OutputCodec};
 use crate::optical_flow::MotionField;
 
 /// Resolved pipeline configuration — all CLI/config/defaults merged.
@@ -33,6 +34,8 @@ pub struct PipelineConfig {
     pub maxine_upscale_factor: u32,
     pub interp_enabled: bool,
     pub maxine_in_fused_batch: bool,
+    pub input_encoding: InputEncoding,
+    pub output_codec: OutputCodec,
 }
 
 impl PipelineConfig {

--- a/crates/dorea-cli/src/probe.rs
+++ b/crates/dorea-cli/src/probe.rs
@@ -1,0 +1,44 @@
+//! `dorea probe` — detect container, codec, bit depth, and suggest flags.
+
+use std::path::PathBuf;
+use clap::Args;
+use anyhow::{Context, Result};
+use dorea_video::ffmpeg::{self, InputEncoding};
+
+#[derive(Args, Debug)]
+pub struct ProbeArgs {
+    /// Input video file
+    #[arg(long)]
+    pub input: PathBuf,
+}
+
+pub fn run(args: ProbeArgs) -> Result<()> {
+    let info = ffmpeg::probe(&args.input)
+        .context("ffprobe failed — is ffmpeg installed?")?;
+
+    let encoding = InputEncoding::auto_detect(&info, &args.input);
+
+    println!("File:       {}", args.input.display());
+    println!("Resolution: {}x{}", info.width, info.height);
+    println!("FPS:        {:.3}", info.fps);
+    println!("Duration:   {:.1}s ({} frames)", info.duration_secs, info.frame_count);
+    println!("Codec:      {}", info.codec_name);
+    println!("Pixel fmt:  {}", info.pix_fmt);
+    println!("Bit depth:  {}-bit", info.bits_per_component);
+    println!("Audio:      {}", if info.has_audio { "yes" } else { "no" });
+    println!();
+    println!("Detected encoding: {encoding}");
+
+    if encoding.is_10bit() {
+        println!();
+        println!("Suggested command:");
+        println!("  dorea grade --input {} --input-encoding {} --output-codec prores",
+            args.input.display(), encoding);
+    } else {
+        println!();
+        println!("Suggested command:");
+        println!("  dorea grade --input {}", args.input.display());
+    }
+
+    Ok(())
+}

--- a/crates/dorea-color/src/dlog_m.rs
+++ b/crates/dorea-color/src/dlog_m.rs
@@ -75,7 +75,7 @@ impl TransferFunction for DLogM {
         0.85
     }
 
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "D-Log M"
     }
 }

--- a/crates/dorea-color/src/dlog_m.rs
+++ b/crates/dorea-color/src/dlog_m.rs
@@ -57,6 +57,29 @@ pub fn linear_to_dlog_m(x: f32) -> f32 {
     encoded.clamp(0.0, 1.0) as f32
 }
 
+use crate::TransferFunction;
+
+/// D-Log M transfer function (DJI Action 4).
+pub struct DLogM;
+
+impl TransferFunction for DLogM {
+    fn to_linear(&self, encoded: f32) -> f32 {
+        dlog_m_to_linear(encoded)
+    }
+
+    fn from_linear(&self, linear: f32) -> f32 {
+        linear_to_dlog_m(linear)
+    }
+
+    fn shoulder(&self) -> f32 {
+        0.85
+    }
+
+    fn name(&self) -> &'static str {
+        "D-Log M"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -82,5 +105,15 @@ mod tests {
             (linear - 0.18).abs() < 0.02,
             "Middle grey decode: expected ~0.18, got {linear}"
         );
+    }
+
+    #[test]
+    fn test_dlog_m_as_trait_object() {
+        let tf: Box<dyn crate::TransferFunction> = Box::new(super::DLogM);
+        let encoded = tf.from_linear(0.18);
+        let decoded = tf.to_linear(encoded);
+        assert!((decoded - 0.18).abs() < 1e-4, "Trait round-trip: expected ~0.18, got {decoded}");
+        assert_eq!(tf.shoulder(), 0.85);
+        assert_eq!(tf.name(), "D-Log M");
     }
 }

--- a/crates/dorea-color/src/ilog.rs
+++ b/crates/dorea-color/src/ilog.rs
@@ -60,7 +60,7 @@ impl TransferFunction for ILog {
         0.88
     }
 
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "I-Log"
     }
 }

--- a/crates/dorea-color/src/ilog.rs
+++ b/crates/dorea-color/src/ilog.rs
@@ -1,0 +1,112 @@
+//! I-Log transfer function (Insta360 X5).
+//!
+//! Uses S-Log3 as a proxy curve until empirical extraction is available.
+//! Replace with `LutBased` once a 1D .cube file is produced from a
+//! grayscale chart shot on the X5.
+
+use crate::TransferFunction;
+
+// Sony S-Log3 parameters (normalised, i.e. code value / 1023)
+// Log segment: encoded = (420 + 261.5 * log10((x + 0.01) / 0.19)) / 1023
+//              => A * log10(x + B) + D,  where B = 0.01, D = 420/1023, A = 261.5/1023
+// Linear segment: encoded = (x * slope_cv + 95) / 1023
+//              => slope_cv = (171.2102946929 - 95) / 0.01125
+const A: f64 = 261.5 / 1023.0;
+const B: f64 = 0.01;
+const D: f64 = 420.0 / 1023.0;
+// Linear-segment slope (CV/linear unit, then normalised)
+const LIN_SLOPE: f64 = (171.2102946929 - 95.0) / 0.01125 / 1023.0;
+const LIN_OFFSET: f64 = 95.0 / 1023.0;
+// Linear cut point: below this, encoding is linear
+const LIN_CUT: f64 = 0.01125;
+// Encoded cut point: S-Log3 value at LIN_CUT (≈ 171.2/1023)
+const ENC_CUT: f64 = 171.2102946929 / 1023.0;
+
+/// Convert I-Log (S-Log3 proxy) encoded value to scene-linear light.
+pub fn ilog_to_linear(x: f32) -> f32 {
+    let x = x as f64;
+    let linear = if x >= ENC_CUT {
+        10_f64.powf((x - D) / A) * 0.19 - B
+    } else {
+        (x - LIN_OFFSET) / LIN_SLOPE
+    };
+    linear.max(0.0) as f32
+}
+
+/// Convert scene-linear light to I-Log (S-Log3 proxy) encoding.
+pub fn linear_to_ilog(x: f32) -> f32 {
+    let x = x as f64;
+    let encoded = if x >= LIN_CUT {
+        A * ((x + B) / 0.19).log10() + D
+    } else {
+        x * LIN_SLOPE + LIN_OFFSET
+    };
+    encoded.clamp(0.0, 1.0) as f32
+}
+
+/// I-Log transfer function (Insta360 X5, S-Log3 proxy).
+pub struct ILog;
+
+impl TransferFunction for ILog {
+    fn to_linear(&self, encoded: f32) -> f32 {
+        ilog_to_linear(encoded)
+    }
+
+    fn from_linear(&self, linear: f32) -> f32 {
+        linear_to_ilog(linear)
+    }
+
+    fn shoulder(&self) -> f32 {
+        0.88
+    }
+
+    fn name(&self) -> &'static str {
+        "I-Log"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ilog_round_trip() {
+        let values = [0.0_f32, 0.01, 0.05, 0.18, 0.5, 0.9, 1.0];
+        for &v in &values {
+            let encoded = linear_to_ilog(v);
+            let decoded = ilog_to_linear(encoded);
+            assert!(
+                (decoded - v).abs() < 1e-4,
+                "Round-trip failed for {v}: encoded={encoded}, decoded={decoded}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_ilog_middle_grey() {
+        // S-Log3 middle grey: 18% linear ≈ 0.41 encoded
+        let encoded = linear_to_ilog(0.18);
+        assert!(
+            (0.35..0.50).contains(&encoded),
+            "Middle grey encode: expected 0.35–0.50, got {encoded}"
+        );
+    }
+
+    #[test]
+    fn test_ilog_monotonic() {
+        let mut prev = ilog_to_linear(0.0);
+        for i in 1..=100 {
+            let x = i as f32 / 100.0;
+            let lin = ilog_to_linear(x);
+            assert!(lin >= prev, "Non-monotonic at x={x}: {lin} < {prev}");
+            prev = lin;
+        }
+    }
+
+    #[test]
+    fn test_ilog_trait() {
+        let tf: Box<dyn crate::TransferFunction> = Box::new(ILog);
+        assert_eq!(tf.shoulder(), 0.88);
+        assert_eq!(tf.name(), "I-Log");
+    }
+}

--- a/crates/dorea-color/src/lib.rs
+++ b/crates/dorea-color/src/lib.rs
@@ -2,6 +2,7 @@ pub mod dlog_m;
 pub mod hsv;
 pub mod ilog;
 pub mod lab;
+pub mod lut_transfer;
 
 /// Camera log curve abstraction. Implementations decode/encode between
 /// a camera-specific log encoding and scene-linear light.
@@ -18,3 +19,4 @@ pub trait TransferFunction {
 
 pub use dlog_m::DLogM;
 pub use ilog::ILog;
+pub use lut_transfer::LutBased;

--- a/crates/dorea-color/src/lib.rs
+++ b/crates/dorea-color/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod dlog_m;
 pub mod hsv;
+pub mod ilog;
 pub mod lab;
 
 /// Camera log curve abstraction. Implementations decode/encode between
@@ -16,3 +17,4 @@ pub trait TransferFunction {
 }
 
 pub use dlog_m::DLogM;
+pub use ilog::ILog;

--- a/crates/dorea-color/src/lib.rs
+++ b/crates/dorea-color/src/lib.rs
@@ -14,7 +14,7 @@ pub trait TransferFunction {
     /// Highlight rolloff shoulder (0.0–1.0). Higher = later compression.
     fn shoulder(&self) -> f32;
     /// Human-readable name (e.g. "D-Log M").
-    fn name(&self) -> &'static str;
+    fn name(&self) -> &str;
 }
 
 pub use dlog_m::DLogM;

--- a/crates/dorea-color/src/lib.rs
+++ b/crates/dorea-color/src/lib.rs
@@ -1,3 +1,18 @@
 pub mod dlog_m;
 pub mod hsv;
 pub mod lab;
+
+/// Camera log curve abstraction. Implementations decode/encode between
+/// a camera-specific log encoding and scene-linear light.
+pub trait TransferFunction {
+    /// Decode a log-encoded value to scene-linear light.
+    fn to_linear(&self, encoded: f32) -> f32;
+    /// Encode a scene-linear light value to log encoding.
+    fn from_linear(&self, linear: f32) -> f32;
+    /// Highlight rolloff shoulder (0.0–1.0). Higher = later compression.
+    fn shoulder(&self) -> f32;
+    /// Human-readable name (e.g. "D-Log M").
+    fn name(&self) -> &'static str;
+}
+
+pub use dlog_m::DLogM;

--- a/crates/dorea-color/src/lut_transfer.rs
+++ b/crates/dorea-color/src/lut_transfer.rs
@@ -85,9 +85,8 @@ impl TransferFunction for LutBased {
         self.shoulder
     }
 
-    fn name(&self) -> &'static str {
-        // Leak to get 'static. LutBased lives for the pipeline duration.
-        Box::leak(self.name.clone().into_boxed_str())
+    fn name(&self) -> &str {
+        &self.name
     }
 }
 

--- a/crates/dorea-color/src/lut_transfer.rs
+++ b/crates/dorea-color/src/lut_transfer.rs
@@ -1,0 +1,188 @@
+//! 1D LUT-based transfer function.
+//!
+//! Loads a 1D .cube file as a transfer function for cameras whose exact
+//! log curve is unknown. Drop in an empirical extraction to replace the
+//! S-Log3 proxy for I-Log.
+
+use crate::TransferFunction;
+use std::path::Path;
+
+/// A transfer function defined by a 1D lookup table.
+pub struct LutBased {
+    forward: Vec<f32>,
+    inverse: Vec<f32>,
+    shoulder: f32,
+    name: String,
+}
+
+impl LutBased {
+    /// Build from a forward LUT (encoded → linear).
+    /// The inverse is computed by table inversion.
+    pub fn new(forward: Vec<f32>, shoulder: f32, name: String) -> Self {
+        let inverse = invert_1d_lut(&forward);
+        Self { forward, inverse, shoulder, name }
+    }
+
+    /// Load from a 1D .cube file.
+    pub fn from_cube_file(path: &Path, shoulder: f32) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+
+        let mut size: Option<usize> = None;
+        let mut values: Vec<f32> = Vec::new();
+        let mut title = path.file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "custom".to_string());
+
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("TITLE") {
+                title = rest.trim().trim_matches('"').to_string();
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("LUT_1D_SIZE") {
+                size = Some(rest.trim().parse::<usize>()
+                    .map_err(|e| format!("bad LUT_1D_SIZE: {e}"))?);
+                continue;
+            }
+            if line.starts_with("LUT_3D_SIZE") || line.starts_with("DOMAIN_") {
+                continue;
+            }
+            let first_token = line.split_whitespace().next().unwrap_or("");
+            if let Ok(v) = first_token.parse::<f32>() {
+                values.push(v);
+            }
+        }
+
+        if let Some(sz) = size {
+            if values.len() != sz {
+                return Err(format!(
+                    "LUT_1D_SIZE={sz} but found {} values", values.len()
+                ));
+            }
+        }
+        if values.len() < 2 {
+            return Err("LUT must have at least 2 entries".to_string());
+        }
+
+        Ok(Self::new(values, shoulder, title))
+    }
+}
+
+impl TransferFunction for LutBased {
+    fn to_linear(&self, encoded: f32) -> f32 {
+        lerp_lut(&self.forward, encoded)
+    }
+
+    fn from_linear(&self, linear: f32) -> f32 {
+        lerp_lut(&self.inverse, linear)
+    }
+
+    fn shoulder(&self) -> f32 {
+        self.shoulder
+    }
+
+    fn name(&self) -> &'static str {
+        // Leak to get 'static. LutBased lives for the pipeline duration.
+        Box::leak(self.name.clone().into_boxed_str())
+    }
+}
+
+fn lerp_lut(lut: &[f32], x: f32) -> f32 {
+    let n = lut.len();
+    if n == 0 { return x; }
+    let x = x.clamp(0.0, 1.0);
+    let pos = x * (n - 1) as f32;
+    let lo = (pos as usize).min(n - 2);
+    let hi = lo + 1;
+    let frac = pos - lo as f32;
+    lut[lo] * (1.0 - frac) + lut[hi] * frac
+}
+
+fn invert_1d_lut(forward: &[f32]) -> Vec<f32> {
+    let n = forward.len();
+    let mut inverse = vec![0.0f32; n];
+    let out_min = forward[0];
+    let out_max = forward[n - 1];
+    let range = (out_max - out_min).max(1e-10);
+
+    for i in 0..n {
+        let target = i as f32 / (n - 1) as f32;
+        let target_scaled = out_min + target * range;
+        let mut lo = 0usize;
+        let mut hi = n - 1;
+        while lo < hi - 1 {
+            let mid = (lo + hi) / 2;
+            if forward[mid] <= target_scaled {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let denom = (forward[hi] - forward[lo]).max(1e-10);
+        let frac = (target_scaled - forward[lo]) / denom;
+        inverse[i] = (lo as f32 + frac) / (n - 1) as f32;
+    }
+    inverse
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity_lut(n: usize) -> Vec<f32> {
+        (0..n).map(|i| i as f32 / (n - 1) as f32).collect()
+    }
+
+    #[test]
+    fn test_identity_round_trip() {
+        let lut = LutBased::new(identity_lut(256), 0.90, "identity".to_string());
+        for i in 0..=10 {
+            let x = i as f32 / 10.0;
+            let linear = lut.to_linear(x);
+            let encoded = lut.from_linear(linear);
+            assert!(
+                (encoded - x).abs() < 0.01,
+                "Identity round-trip failed at {x}: linear={linear}, encoded={encoded}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gamma_lut_round_trip() {
+        let n = 1024;
+        let forward: Vec<f32> = (0..n)
+            .map(|i| (i as f32 / (n - 1) as f32).powf(2.2))
+            .collect();
+        let lut = LutBased::new(forward, 0.85, "gamma2.2".to_string());
+        let values = [0.0, 0.1, 0.18, 0.5, 0.8, 1.0];
+        for &v in &values {
+            let linear = lut.to_linear(v);
+            let back = lut.from_linear(linear);
+            assert!(
+                (back - v).abs() < 0.01,
+                "Gamma round-trip failed at {v}: linear={linear}, back={back}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_lerp_lut_boundaries() {
+        let lut = vec![0.0, 0.5, 1.0];
+        assert!((lerp_lut(&lut, 0.0) - 0.0).abs() < 1e-6);
+        assert!((lerp_lut(&lut, 0.5) - 0.5).abs() < 1e-6);
+        assert!((lerp_lut(&lut, 1.0) - 1.0).abs() < 1e-6);
+        assert!((lerp_lut(&lut, 0.25) - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_trait_impl() {
+        let lut = LutBased::new(identity_lut(256), 0.90, "test".to_string());
+        let tf: &dyn crate::TransferFunction = &lut;
+        assert_eq!(tf.shoulder(), 0.90);
+        assert_eq!(tf.name(), "test");
+    }
+}

--- a/crates/dorea-gpu/src/cuda/kernels/combined_lut.cu
+++ b/crates/dorea-gpu/src/cuda/kernels/combined_lut.cu
@@ -212,3 +212,199 @@ __global__ void combined_lut_kernel(
     pixels_out[idx * 3 + 1] = (unsigned char)(__float2uint_rn(fminf(fmaxf(g_out, 0.0f), 1.0f) * 255.0f));
     pixels_out[idx * 3 + 2] = (unsigned char)(__float2uint_rn(fminf(fmaxf(b_out, 0.0f), 1.0f) * 255.0f));
 }
+
+
+/**
+ * combined_lut_kernel_16 — 10-bit (u16) variant of combined_lut_kernel.
+ *
+ * Identical grading logic, but reads/writes unsigned short (u16) pixels
+ * normalised to [0, 65535] instead of unsigned char [0, 255].
+ * Dither amplitude is scaled to ±1/65535 for 16-bit quantisation.
+ */
+extern "C"
+__global__ void combined_lut_kernel_16(
+    const unsigned short* __restrict__ pixels_in,
+    const float*          __restrict__ depth,
+    // Texture set A (active / "before" keyframe)
+    const unsigned long long* __restrict__ textures_a,
+    const float*              __restrict__ zone_boundaries_a,
+    // Texture set B ("after" keyframe)
+    const unsigned long long* __restrict__ textures_b,
+    const float*              __restrict__ zone_boundaries_b,
+    // Blend factor: 0.0 = all A, 1.0 = all B
+    float blend_t,
+    unsigned short*       __restrict__ pixels_out,
+    int n_pixels,
+    int n_zones,
+    int grid_size,
+    // Depth map dimensions (may differ from frame — kernel does bilinear sampling)
+    int frame_w,
+    int frame_h,
+    int depth_w,
+    int depth_h,
+    // Class mask (0=water, 1=diver) at mask resolution. NULL if no YOLO-seg.
+    const unsigned char* __restrict__ class_mask,
+    int mask_w,
+    int mask_h,
+    // Median diver depth — all diver pixels use this value for uniform correction.
+    float diver_depth
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n_pixels) return;
+
+    float r = pixels_in[idx * 3 + 0] * (1.0f / 65535.0f);
+    float g = pixels_in[idx * 3 + 1] * (1.0f / 65535.0f);
+    float b = pixels_in[idx * 3 + 2] * (1.0f / 65535.0f);
+
+    // Bilinear sample depth at proxy resolution — avoids blocky upscale artifacts.
+    float d;
+    if (depth_w == frame_w && depth_h == frame_h) {
+        d = depth[idx];
+    } else {
+        int px = idx % frame_w;
+        int py = idx / frame_w;
+        float sx = (float)px * (float)(depth_w - 1) / (float)(frame_w - 1);
+        float sy = (float)py * (float)(depth_h - 1) / (float)(frame_h - 1);
+        int x0 = (int)sx;
+        int y0 = (int)sy;
+        int x1 = min(x0 + 1, depth_w - 1);
+        int y1 = min(y0 + 1, depth_h - 1);
+        float fx = sx - (float)x0;
+        float fy = sy - (float)y0;
+        d = depth[y0 * depth_w + x0] * (1.0f - fx) * (1.0f - fy)
+          + depth[y0 * depth_w + x1] * fx * (1.0f - fy)
+          + depth[y1 * depth_w + x0] * (1.0f - fx) * fy
+          + depth[y1 * depth_w + x1] * fx * fy;
+    }
+
+    // Depth dithering: add sub-zone noise to break up banding at zone transitions.
+    {
+        unsigned int hash = (unsigned int)(idx * 2654435761u);
+        float noise = ((float)(hash & 0xFFFF) / 65535.0f - 0.5f);
+        float avg_zone_width = 1.0f / (float)n_zones;
+        d += noise * avg_zone_width * 0.5f;
+        d = fminf(fmaxf(d, 0.0f), 1.0f);
+    }
+
+    // If YOLO-seg mask available and this pixel is a diver, override depth.
+    if (class_mask != 0) {
+        int px = idx % frame_w;
+        int py = idx / frame_w;
+        float mx = (float)px * (float)(mask_w - 1) / (float)(frame_w - 1);
+        float my = (float)py * (float)(mask_h - 1) / (float)(frame_h - 1);
+        int mi = min((int)my, mask_h - 1) * mask_w + min((int)mx, mask_w - 1);
+        if (class_mask[mi] > 0) {
+            d = diver_depth;
+        }
+    }
+
+    float gs = (float)(grid_size - 1);
+
+    // --- Sample texture set A ---
+    float total_w_a = 0.0f;
+    float4 blended_a = {0.0f, 0.0f, 0.0f, 0.0f};
+    for (int z = 0; z < n_zones; z++) {
+        float z_lo = zone_boundaries_a[z];
+        float z_hi = zone_boundaries_a[z + 1];
+        float z_width = z_hi - z_lo;
+        if (z_width < 1e-6f) continue;
+        float z_center = 0.5f * (z_lo + z_hi);
+        float dist = fabsf(d - z_center);
+        float blend_radius = z_width * 2.0f;
+        float w = fmaxf(1.0f - dist / blend_radius, 0.0f);
+        w = w * w;
+        if (w < 1e-6f) continue;
+        cudaTextureObject_t tex = (cudaTextureObject_t)textures_a[z];
+        float4 s = tex3D<float4>(tex, r * gs, g * gs, b * gs);
+        blended_a.x += s.x * w;
+        blended_a.y += s.y * w;
+        blended_a.z += s.z * w;
+        total_w_a += w;
+    }
+
+    float r_a, g_a, b_a;
+    if (total_w_a > 1e-6f) {
+        r_a = blended_a.x / total_w_a;
+        g_a = blended_a.y / total_w_a;
+        b_a = blended_a.z / total_w_a;
+    } else {
+        r_a = r; g_a = g; b_a = b;
+    }
+
+    // --- Early out: skip set B when blend_t ≈ 0 (on keyframes) ---
+    float r_out, g_out, b_out;
+    if (blend_t < 1e-4f) {
+        r_out = r_a; g_out = g_a; b_out = b_a;
+    } else {
+        // --- Sample texture set B ---
+        float total_w_b = 0.0f;
+        float4 blended_b = {0.0f, 0.0f, 0.0f, 0.0f};
+        for (int z = 0; z < n_zones; z++) {
+            float z_lo = zone_boundaries_b[z];
+            float z_hi = zone_boundaries_b[z + 1];
+            float z_width = z_hi - z_lo;
+            if (z_width < 1e-6f) continue;
+            float z_center = 0.5f * (z_lo + z_hi);
+            float dist = fabsf(d - z_center);
+            float blend_radius = z_width * 2.0f;
+            float w = fmaxf(1.0f - dist / blend_radius, 0.0f);
+            w = w * w;
+            if (w < 1e-6f) continue;
+            cudaTextureObject_t tex = (cudaTextureObject_t)textures_b[z];
+            float4 s = tex3D<float4>(tex, r * gs, g * gs, b * gs);
+            blended_b.x += s.x * w;
+            blended_b.y += s.y * w;
+            blended_b.z += s.z * w;
+            total_w_b += w;
+        }
+
+        float r_b, g_b, b_b;
+        if (total_w_b > 1e-6f) {
+            r_b = blended_b.x / total_w_b;
+            g_b = blended_b.y / total_w_b;
+            b_b = blended_b.z / total_w_b;
+        } else {
+            r_b = r; g_b = g; b_b = b;
+        }
+
+        // Temporal blend
+        float inv_t = 1.0f - blend_t;
+        r_out = r_a * inv_t + r_b * blend_t;
+        g_out = g_a * inv_t + g_b * blend_t;
+        b_out = b_a * inv_t + b_b * blend_t;
+    }
+
+    // Depth-dependent strength
+    float depth_strength = fminf(d / 0.15f, 1.0f);
+
+    // Clamp per-channel correction
+    float max_shift = 0.35f;
+    r_out = r + fminf(fmaxf(r_out - r, -max_shift), max_shift) * depth_strength;
+    g_out = g + fminf(fmaxf(g_out - g, -max_shift), max_shift) * depth_strength;
+    b_out = b + fminf(fmaxf(b_out - b, -max_shift), max_shift) * depth_strength;
+
+    // Output dithering: ±1/65535 triangular-PDF noise per channel (16-bit scale).
+    {
+        unsigned int h1 = (unsigned int)(idx * 2654435761u);
+        unsigned int h2 = (unsigned int)(idx * 340573321u + 1013904223u);
+        float u1 = (float)(h1 & 0xFFFF) / 65536.0f;
+        float u2 = (float)(h2 & 0xFFFF) / 65536.0f;
+        float tri = (u1 + u2 - 1.0f);
+        float dither = tri / 65535.0f;
+        r_out += dither;
+        unsigned int h3 = h1 ^ (h2 << 13);
+        unsigned int h4 = h2 ^ (h1 >> 7);
+        float u3 = (float)(h3 & 0xFFFF) / 65536.0f;
+        float u4 = (float)(h4 & 0xFFFF) / 65536.0f;
+        g_out += (u3 + u4 - 1.0f) / 65535.0f;
+        unsigned int h5 = h1 ^ (h2 >> 5) ^ 0xDEADBEEF;
+        unsigned int h6 = h2 ^ (h1 << 11) ^ 0xCAFEBABE;
+        float u5 = (float)(h5 & 0xFFFF) / 65536.0f;
+        float u6 = (float)(h6 & 0xFFFF) / 65536.0f;
+        b_out += (u5 + u6 - 1.0f) / 65535.0f;
+    }
+
+    pixels_out[idx * 3 + 0] = (unsigned short)(__float2uint_rn(fminf(fmaxf(r_out, 0.0f), 1.0f) * 65535.0f));
+    pixels_out[idx * 3 + 1] = (unsigned short)(__float2uint_rn(fminf(fmaxf(g_out, 0.0f), 1.0f) * 65535.0f));
+    pixels_out[idx * 3 + 2] = (unsigned short)(__float2uint_rn(fminf(fmaxf(b_out, 0.0f), 1.0f) * 65535.0f));
+}

--- a/crates/dorea-gpu/src/cuda/mod.rs
+++ b/crates/dorea-gpu/src/cuda/mod.rs
@@ -58,6 +58,31 @@ fn alloc_frame_buffers(dev: &Arc<CudaDevice>, width: usize, height: usize) -> Re
     })
 }
 
+/// Pre-allocated device buffers for 16-bit (u16) pixel I/O.
+/// Like `FrameBuffers` but with `CudaSlice<u16>` for pixel data.
+/// No `d_depth` field — depth is uploaded separately at proxy resolution
+/// (may differ from frame resolution) in `grade_frame_blended_16`.
+#[cfg(feature = "cuda")]
+struct FrameBuffers16 {
+    width: usize,
+    height: usize,
+    d_pixels_in: CudaSlice<u16>,    // n * 3
+    d_pixels_out: CudaSlice<u16>,   // n * 3
+}
+
+#[cfg(feature = "cuda")]
+fn alloc_frame_buffers_16(dev: &Arc<CudaDevice>, width: usize, height: usize) -> Result<FrameBuffers16, GpuError> {
+    let n = width.checked_mul(height).ok_or_else(|| {
+        GpuError::InvalidInput("frame dimensions overflow usize".into())
+    })?;
+    Ok(FrameBuffers16 {
+        width,
+        height,
+        d_pixels_in: dev.alloc_zeros(n * 3).map_err(map_cudarc_error)?,
+        d_pixels_out: dev.alloc_zeros(n * 3).map_err(map_cudarc_error)?,
+    })
+}
+
 /// CUDA grader: holds a device handle and the precomputed combined LUT textures.
 ///
 /// Create once via `CudaGrader::new(calibration, params)`, reuse across frames.
@@ -94,7 +119,7 @@ impl CudaGrader {
         device.load_ptx(
             Ptx::from_src(COMBINED_LUT_PTX),
             "combined_lut",
-            &["combined_lut_kernel"],
+            &["combined_lut_kernel", "combined_lut_kernel_16"],
         ).map_err(|e| GpuError::ModuleLoad(format!("load combined_lut PTX: {e}")))?;
 
         // Build combined LUT textures (GPU build kernel runs here, ~<1ms)
@@ -517,7 +542,8 @@ pub struct AdaptiveGrader {
     d_textures_b: CudaSlice<u64>,             // inactive texture handles (constant after allocate)
     d_bounds_a:   RefCell<CudaSlice<f32>>,    // active boundaries (updated on swap/rebuild)
     d_bounds_b:   RefCell<CudaSlice<f32>>,    // inactive boundaries (updated on swap/rebuild)
-    frame_bufs:   RefCell<Option<FrameBuffers>>, // resolution-keyed
+    frame_bufs:   RefCell<Option<FrameBuffers>>,   // resolution-keyed (u8 path)
+    frame_bufs_16: RefCell<Option<FrameBuffers16>>, // resolution-keyed (u16 path)
     device:       Arc<CudaDevice>,            // dropped last — destroys CUDA context
     _not_send:    std::marker::PhantomData<*const ()>,
 }
@@ -544,7 +570,7 @@ impl AdaptiveGrader {
         device.load_ptx(
             Ptx::from_src(COMBINED_LUT_PTX),
             "combined_lut",
-            &["combined_lut_kernel"],
+            &["combined_lut_kernel", "combined_lut_kernel_16"],
         ).map_err(|e| GpuError::ModuleLoad(format!("load combined_lut PTX: {e}")))?;
 
         device.load_ptx(
@@ -578,6 +604,7 @@ impl AdaptiveGrader {
             d_bounds_a: RefCell::new(d_bounds_a),
             d_bounds_b: RefCell::new(d_bounds_b),
             frame_bufs: RefCell::new(None),
+            frame_bufs_16: RefCell::new(None),
             device,
             _not_send: std::marker::PhantomData,
         })
@@ -762,6 +789,132 @@ impl AdaptiveGrader {
         // Download result
         let slot = self.frame_bufs.borrow();
         let bufs = slot.as_ref().expect("frame_bufs allocated above");
+        let result = dev.dtoh_sync_copy(&bufs.d_pixels_out).map_err(map_cudarc_error)?;
+        Ok(result)
+    }
+
+    /// Grade one frame with dual-texture temporal blending — 16-bit (u16) I/O variant.
+    ///
+    /// Identical to `grade_frame_blended` but reads/writes `u16` pixel data instead of `u8`.
+    /// Uses `combined_lut_kernel_16` which normalises to [0, 65535].
+    pub fn grade_frame_blended_16(
+        &self,
+        pixels: &[u16],
+        depth: &[f32],
+        width: usize,
+        height: usize,
+        depth_w: usize,
+        depth_h: usize,
+        blend_t: f32,
+        class_mask: Option<&[u8]>,
+        mask_w: usize,
+        mask_h: usize,
+        diver_depth: f32,
+    ) -> Result<Vec<u16>, GpuError> {
+        let n = width.checked_mul(height).ok_or_else(|| {
+            GpuError::InvalidInput("frame dimensions overflow usize".into())
+        })?;
+        if pixels.len() != n * 3 {
+            return Err(GpuError::InvalidInput(format!(
+                "pixels len {} != {}*3", pixels.len(), n
+            )));
+        }
+        let dn = depth_w.checked_mul(depth_h).ok_or_else(|| {
+            GpuError::InvalidInput("depth dimensions overflow usize".into())
+        })?;
+        if depth.len() != dn {
+            return Err(GpuError::InvalidInput(format!(
+                "depth len {} != depth_w*depth_h {}", depth.len(), dn
+            )));
+        }
+        let dev = &self.device;
+
+        // Ensure 16-bit frame buffers exist at the correct resolution, then upload per-frame data.
+        {
+            let mut slot = self.frame_bufs_16.borrow_mut();
+            let needs = slot.as_ref().map_or(true, |b| b.width != width || b.height != height);
+            if needs {
+                *slot = Some(alloc_frame_buffers_16(dev, width, height)?);
+            }
+            let bufs = slot.as_mut().expect("frame_bufs_16 allocated above");
+            dev.htod_sync_copy_into(pixels, &mut bufs.d_pixels_in).map_err(map_cudarc_error)?;
+        }
+
+        // Upload depth separately — may be at different resolution than frame.
+        let d_depth = dev.htod_sync_copy(depth).map_err(map_cudarc_error)?;
+
+        // Determine which cached device slices correspond to the current active/inactive sets.
+        let active_idx = self.adaptive_lut.active_index();
+        let (d_tex_active, d_bounds_active, d_tex_inactive, d_bounds_inactive) = if active_idx == 0 {
+            (&self.d_textures_a, &self.d_bounds_a, &self.d_textures_b, &self.d_bounds_b)
+        } else {
+            (&self.d_textures_b, &self.d_bounds_b, &self.d_textures_a, &self.d_bounds_a)
+        };
+
+        // Three distinct RefCells borrowed concurrently — safe because they are independent fields.
+        {
+            let slot = self.frame_bufs_16.borrow();
+            let bufs = slot.as_ref().expect("frame_bufs_16 allocated above");
+            let bounds_a = d_bounds_active.borrow();
+            let bounds_b = d_bounds_inactive.borrow();
+
+            let func = dev.get_func("combined_lut", "combined_lut_kernel_16")
+                .ok_or_else(|| GpuError::ModuleLoad("combined_lut_kernel_16 not found".into()))?;
+            let cfg = LaunchConfig {
+                grid_dim: (div_ceil(n as u32, 256), 1, 1),
+                block_dim: (256, 1, 1),
+                shared_mem_bytes: 0,
+            };
+
+            let n_i32 = n as i32;
+            let nz_i32 = self.adaptive_lut.runtime_n_zones as i32;
+            let gs_i32 = self.adaptive_lut.grid_size as i32;
+            let fw_i32 = width as i32;
+            let fh_i32 = height as i32;
+            let dw_i32 = depth_w as i32;
+            let dh_i32 = depth_h as i32;
+            let mw_i32 = mask_w as i32;
+            let mh_i32 = mask_h as i32;
+            use cudarc::driver::{DeviceRepr, DevicePtr};
+
+            // Upload class mask if available, otherwise pass null device pointer
+            let d_mask: Option<CudaSlice<u8>> = class_mask.map(|m| {
+                dev.htod_sync_copy(m).expect("mask upload failed")
+            });
+            let mask_ptr: u64 = match &d_mask {
+                Some(s) => *s.device_ptr() as u64,
+                None => 0u64,
+            };
+
+            let mut args: [*mut std::ffi::c_void; 19] = [
+                (&bufs.d_pixels_in).as_kernel_param(),
+                (&d_depth).as_kernel_param(),
+                d_tex_active.as_kernel_param(),
+                (&*bounds_a).as_kernel_param(),
+                d_tex_inactive.as_kernel_param(),
+                (&*bounds_b).as_kernel_param(),
+                blend_t.as_kernel_param(),
+                (&bufs.d_pixels_out).as_kernel_param(),
+                n_i32.as_kernel_param(),
+                nz_i32.as_kernel_param(),
+                gs_i32.as_kernel_param(),
+                fw_i32.as_kernel_param(),
+                fh_i32.as_kernel_param(),
+                dw_i32.as_kernel_param(),
+                dh_i32.as_kernel_param(),
+                mask_ptr.as_kernel_param(),
+                mw_i32.as_kernel_param(),
+                mh_i32.as_kernel_param(),
+                diver_depth.as_kernel_param(),
+            ];
+            unsafe {
+                func.launch(cfg, &mut args[..])
+            }.map_err(map_cudarc_error)?;
+        }
+
+        // Download result
+        let slot = self.frame_bufs_16.borrow();
+        let bufs = slot.as_ref().expect("frame_bufs_16 allocated above");
         let result = dev.dtoh_sync_copy(&bufs.d_pixels_out).map_err(map_cudarc_error)?;
         Ok(result)
     }

--- a/crates/dorea-gpu/src/cuda/mod.rs
+++ b/crates/dorea-gpu/src/cuda/mod.rs
@@ -752,9 +752,9 @@ impl AdaptiveGrader {
             use cudarc::driver::{DeviceRepr, DevicePtr};
 
             // Upload class mask if available, otherwise pass null device pointer
-            let d_mask: Option<CudaSlice<u8>> = class_mask.map(|m| {
-                dev.htod_sync_copy(m).expect("mask upload failed")
-            });
+            let d_mask: Option<CudaSlice<u8>> = class_mask
+                .map(|m| dev.htod_sync_copy(m).map_err(map_cudarc_error))
+                .transpose()?;
             let mask_ptr: u64 = match &d_mask {
                 Some(s) => *s.device_ptr() as u64,
                 None => 0u64,
@@ -878,9 +878,9 @@ impl AdaptiveGrader {
             use cudarc::driver::{DeviceRepr, DevicePtr};
 
             // Upload class mask if available, otherwise pass null device pointer
-            let d_mask: Option<CudaSlice<u8>> = class_mask.map(|m| {
-                dev.htod_sync_copy(m).expect("mask upload failed")
-            });
+            let d_mask: Option<CudaSlice<u8>> = class_mask
+                .map(|m| dev.htod_sync_copy(m).map_err(map_cudarc_error))
+                .transpose()?;
             let mask_ptr: u64 = match &d_mask {
                 Some(s) => *s.device_ptr() as u64,
                 None => 0u64,

--- a/crates/dorea-gpu/src/lib.rs
+++ b/crates/dorea-gpu/src/lib.rs
@@ -196,3 +196,28 @@ pub fn grade_frame_with_adaptive_grader(
     }
     grader.grade_frame_blended(pixels, depth, width, height, depth_w, depth_h, blend_t, None, 0, 0, 0.5)
 }
+
+/// Grade a single 16-bit frame using an existing `AdaptiveGrader` with dual-texture blending.
+///
+/// Identical to `grade_frame_with_adaptive_grader` but reads/writes `u16` pixel data.
+/// Uses `combined_lut_kernel_16` which normalises to [0, 65535].
+#[cfg(feature = "cuda")]
+pub fn grade_frame_with_adaptive_grader_16(
+    grader: &cuda::AdaptiveGrader,
+    pixels: &[u16],
+    depth: &[f32],
+    width: usize,
+    height: usize,
+    depth_w: usize,
+    depth_h: usize,
+    blend_t: f32,
+) -> Result<Vec<u16>, GpuError> {
+    if pixels.len() != width * height * 3 {
+        return Err(GpuError::InvalidInput(format!(
+            "pixels length {} != width*height*3 {}",
+            pixels.len(),
+            width * height * 3
+        )));
+    }
+    grader.grade_frame_blended_16(pixels, depth, width, height, depth_w, depth_h, blend_t, None, 0, 0, 0.5)
+}

--- a/crates/dorea-video/src/ffmpeg.rs
+++ b/crates/dorea-video/src/ffmpeg.rs
@@ -20,6 +20,73 @@ pub enum FfmpegError {
     InvalidMetadata(String),
 }
 
+// ---------------------------------------------------------------------------
+// InputEncoding — log-curve / gamma family of the source footage
+// ---------------------------------------------------------------------------
+
+/// Log-curve / colour-science family of the source footage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputEncoding {
+    /// DJI D-Log M (DJI Mini 4 Pro, Osmo Action 4/5, …).
+    DLogM,
+    /// Insta360 Log (X5, X4, …).
+    ILog,
+    /// Standard sRGB / Rec.709 gamma.
+    Srgb,
+}
+
+impl InputEncoding {
+    /// Heuristic: infer encoding from `VideoInfo` and the file path extension.
+    pub fn auto_detect(info: &VideoInfo, path: &std::path::Path) -> Self {
+        let ext = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_lowercase())
+            .unwrap_or_default();
+        if info.codec_name == "prores" || ext == "mov" {
+            return Self::ILog;
+        }
+        if info.bits_per_component >= 10
+            && (info.codec_name == "hevc" || info.codec_name == "h265")
+        {
+            return Self::DLogM;
+        }
+        Self::Srgb
+    }
+
+    /// Returns `true` for encodings that carry 10-bit (or higher) colour data.
+    pub fn is_10bit(&self) -> bool {
+        matches!(self, Self::DLogM | Self::ILog)
+    }
+}
+
+impl std::fmt::Display for InputEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DLogM => write!(f, "dlog-m"),
+            Self::ILog => write!(f, "ilog"),
+            Self::Srgb => write!(f, "srgb"),
+        }
+    }
+}
+
+impl std::str::FromStr for InputEncoding {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s.to_lowercase().as_str() {
+            "dlog-m" | "dlogm" | "dlog_m" => Ok(Self::DLogM),
+            "ilog" | "i-log" => Ok(Self::ILog),
+            "srgb" | "rec709" => Ok(Self::Srgb),
+            other => Err(format!(
+                "unknown encoding '{other}'; expected dlog-m, ilog, or srgb"
+            )),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// VideoInfo
+// ---------------------------------------------------------------------------
+
 /// Video metadata returned by `probe`.
 #[derive(Debug, Clone)]
 pub struct VideoInfo {
@@ -633,6 +700,85 @@ mod tests {
         assert_eq!(info.bits_per_component, 10);
         assert_eq!(info.codec_name, "hevc");
         assert_eq!(info.pix_fmt, "yuv420p10le");
+    }
+
+    // ---- Task 5 tests ----
+
+    #[test]
+    fn input_encoding_auto_detect_dji_hevc_10bit() {
+        let info = VideoInfo {
+            width: 3840,
+            height: 2160,
+            fps: 29.97,
+            duration_secs: 10.0,
+            frame_count: 300,
+            has_audio: false,
+            codec_name: "hevc".to_string(),
+            pix_fmt: "yuv420p10le".to_string(),
+            bits_per_component: 10,
+        };
+        let path = std::path::Path::new("DJI_0001.MP4");
+        assert_eq!(InputEncoding::auto_detect(&info, path), InputEncoding::DLogM);
+    }
+
+    #[test]
+    fn input_encoding_auto_detect_prores_mov() {
+        let info = VideoInfo {
+            width: 3840,
+            height: 2160,
+            fps: 29.97,
+            duration_secs: 10.0,
+            frame_count: 300,
+            has_audio: false,
+            codec_name: "prores".to_string(),
+            pix_fmt: "yuv422p10le".to_string(),
+            bits_per_component: 10,
+        };
+        let path = std::path::Path::new("clip.mov");
+        assert_eq!(InputEncoding::auto_detect(&info, path), InputEncoding::ILog);
+    }
+
+    #[test]
+    fn input_encoding_auto_detect_srgb_h264() {
+        let info = VideoInfo {
+            width: 1920,
+            height: 1080,
+            fps: 30.0,
+            duration_secs: 5.0,
+            frame_count: 150,
+            has_audio: false,
+            codec_name: "h264".to_string(),
+            pix_fmt: "yuv420p".to_string(),
+            bits_per_component: 8,
+        };
+        let path = std::path::Path::new("clip.mp4");
+        assert_eq!(InputEncoding::auto_detect(&info, path), InputEncoding::Srgb);
+    }
+
+    #[test]
+    fn input_encoding_parse() {
+        assert_eq!("dlog-m".parse::<InputEncoding>(), Ok(InputEncoding::DLogM));
+        assert_eq!("dlogm".parse::<InputEncoding>(), Ok(InputEncoding::DLogM));
+        assert_eq!("dlog_m".parse::<InputEncoding>(), Ok(InputEncoding::DLogM));
+        assert_eq!("ilog".parse::<InputEncoding>(), Ok(InputEncoding::ILog));
+        assert_eq!("i-log".parse::<InputEncoding>(), Ok(InputEncoding::ILog));
+        assert_eq!("srgb".parse::<InputEncoding>(), Ok(InputEncoding::Srgb));
+        assert_eq!("rec709".parse::<InputEncoding>(), Ok(InputEncoding::Srgb));
+        assert!("unknown".parse::<InputEncoding>().is_err());
+    }
+
+    #[test]
+    fn input_encoding_is_10bit() {
+        assert!(InputEncoding::DLogM.is_10bit());
+        assert!(InputEncoding::ILog.is_10bit());
+        assert!(!InputEncoding::Srgb.is_10bit());
+    }
+
+    #[test]
+    fn input_encoding_display() {
+        assert_eq!(InputEncoding::DLogM.to_string(), "dlog-m");
+        assert_eq!(InputEncoding::ILog.to_string(), "ilog");
+        assert_eq!(InputEncoding::Srgb.to_string(), "srgb");
     }
 
     #[test]

--- a/crates/dorea-video/src/ffmpeg.rs
+++ b/crates/dorea-video/src/ffmpeg.rs
@@ -33,6 +33,12 @@ pub struct VideoInfo {
     pub frame_count: u64,
     /// Has audio stream.
     pub has_audio: bool,
+    /// Codec name as reported by ffprobe, e.g. `"hevc"`, `"prores"`, `"h264"`.
+    pub codec_name: String,
+    /// Pixel format as reported by ffprobe, e.g. `"yuv420p10le"`, `"yuv422p10le"`.
+    pub pix_fmt: String,
+    /// Bits per colour component (8, 10, 12). Falls back to 0 if unknown.
+    pub bits_per_component: u8,
 }
 
 /// Probe a video file for metadata.
@@ -61,13 +67,16 @@ pub fn probe(input: &Path) -> Result<VideoInfo, FfmpegError> {
         FfmpegError::InvalidMetadata("no streams found".to_string())
     })?;
 
-    let video = streams.iter()
+    let video = streams
+        .iter()
         .find(|s| s["codec_type"].as_str() == Some("video"))
         .ok_or_else(|| FfmpegError::InvalidMetadata("no video stream".to_string()))?;
 
-    let width = video["width"].as_u64()
+    let width = video["width"]
+        .as_u64()
         .ok_or_else(|| FfmpegError::InvalidMetadata("missing width".to_string()))? as usize;
-    let height = video["height"].as_u64()
+    let height = video["height"]
+        .as_u64()
         .ok_or_else(|| FfmpegError::InvalidMetadata("missing height".to_string()))? as usize;
 
     // fps as rational string "30000/1001" or plain "30"
@@ -83,9 +92,42 @@ pub fn probe(input: &Path) -> Result<VideoInfo, FfmpegError> {
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or_else(|| (duration_secs * fps).round() as u64);
 
-    let has_audio = streams.iter().any(|s| s["codec_type"].as_str() == Some("audio"));
+    let has_audio = streams
+        .iter()
+        .any(|s| s["codec_type"].as_str() == Some("audio"));
 
-    Ok(VideoInfo { width, height, fps, duration_secs, frame_count, has_audio })
+    let codec_name = video["codec_name"]
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+    let pix_fmt = video["pix_fmt"]
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+    let bits_per_component = video["bits_per_raw_sample"]
+        .as_str()
+        .and_then(|s| s.parse::<u8>().ok())
+        .unwrap_or_else(|| {
+            if pix_fmt.contains("10") {
+                10
+            } else if pix_fmt.contains("12") {
+                12
+            } else {
+                8
+            }
+        });
+
+    Ok(VideoInfo {
+        width,
+        height,
+        fps,
+        duration_secs,
+        frame_count,
+        has_audio,
+        codec_name,
+        pix_fmt,
+        bits_per_component,
+    })
 }
 
 fn parse_rational(s: &str) -> f64 {
@@ -416,11 +458,13 @@ impl FrameEncoder {
 
         // Check immediately if ffmpeg exited (e.g. bad codec args, permissions, etc.)
         if let Ok(Some(status)) = child.try_wait() {
-            let stderr_msg = stderr.map(|mut s| {
-                let mut buf = String::new();
-                let _ = s.read_to_string(&mut buf);
-                buf
-            }).unwrap_or_default();
+            let stderr_msg = stderr
+                .map(|mut s| {
+                    let mut buf = String::new();
+                    let _ = s.read_to_string(&mut buf);
+                    buf
+                })
+                .unwrap_or_default();
             return Err(FfmpegError::EncodeFailed(format!(
                 "ffmpeg encoder exited immediately (code {:?}): {}",
                 status.code(),
@@ -476,14 +520,17 @@ impl FrameEncoder {
         let stderr = child.stderr.take();
 
         if let Ok(Some(status)) = child.try_wait() {
-            let msg = stderr.map(|mut s| {
-                let mut buf = String::new();
-                let _ = s.read_to_string(&mut buf);
-                buf
-            }).unwrap_or_default();
+            let msg = stderr
+                .map(|mut s| {
+                    let mut buf = String::new();
+                    let _ = s.read_to_string(&mut buf);
+                    buf
+                })
+                .unwrap_or_default();
             return Err(FfmpegError::EncodeFailed(format!(
                 "ffv1 encoder exited immediately (code {:?}): {}",
-                status.code(), msg.trim()
+                status.code(),
+                msg.trim()
             )));
         }
 
@@ -568,6 +615,24 @@ mod tests {
         assert!((parse_rational("25/1") - 25.0).abs() < 0.001);
         assert!((parse_rational("24") - 24.0).abs() < 0.001);
         assert!((parse_rational("0/0") - 30.0).abs() < 0.001); // div-by-zero fallback
+    }
+
+    #[test]
+    fn video_info_has_codec_fields() {
+        let info = VideoInfo {
+            width: 3840,
+            height: 2160,
+            fps: 29.97,
+            duration_secs: 10.0,
+            frame_count: 300,
+            has_audio: true,
+            codec_name: "hevc".to_string(),
+            pix_fmt: "yuv420p10le".to_string(),
+            bits_per_component: 10,
+        };
+        assert_eq!(info.bits_per_component, 10);
+        assert_eq!(info.codec_name, "hevc");
+        assert_eq!(info.pix_fmt, "yuv420p10le");
     }
 
     #[test]

--- a/crates/dorea-video/src/ffmpeg.rs
+++ b/crates/dorea-video/src/ffmpeg.rs
@@ -443,6 +443,153 @@ pub fn extract_frame_at(
     Ok(output.stdout[..expected].to_vec())
 }
 
+// ---------------------------------------------------------------------------
+// Frame16 (16-bit / 10-bit decode path)
+// ---------------------------------------------------------------------------
+
+/// A decoded 16-bit video frame (RGB48, little-endian u16 per channel).
+///
+/// Each pixel is three consecutive `u16` values: R, G, B.
+/// The full buffer length is `width * height * 3` u16 values.
+#[derive(Debug)]
+pub struct Frame16 {
+    pub index: u64,
+    pub pixels: Vec<u16>, // RGB48: width * height * 3
+    pub width: usize,
+    pub height: usize,
+}
+
+impl Frame16 {
+    /// Down-convert to 8-bit by keeping the high byte of each u16.
+    pub fn to_8bit(&self) -> Vec<u8> {
+        self.pixels.iter().map(|&v| (v >> 8) as u8).collect()
+    }
+}
+
+/// Decode all frames from a video file as 16-bit RGB48 (little-endian u16).
+///
+/// Instructs ffmpeg to output `rgb48le`. Suitable for 10-bit and 12-bit sources.
+/// The resulting `Frame16::pixels` contains raw u16 values in the range 0–65535.
+pub fn decode_frames_16bit(
+    input: &Path,
+    info: &VideoInfo,
+) -> Result<impl Iterator<Item = Result<Frame16, FfmpegError>>, FfmpegError> {
+    let child = spawn_decoder_16bit(input, info)?;
+    Ok(FrameReader16::new(child, info.width, info.height))
+}
+
+fn spawn_decoder_16bit(input: &Path, info: &VideoInfo) -> Result<Child, FfmpegError> {
+    let input_str = input.to_str().unwrap_or("");
+    let size_str = format!("{}x{}", info.width, info.height);
+
+    // Try hardware decode first, fall back to software
+    let hw_result = Command::new("ffmpeg")
+        .args([
+            "-hwaccel", "nvdec",
+            "-i", input_str,
+            "-vf", &format!("scale={size_str}"),
+            "-f", "rawvideo",
+            "-pix_fmt", "rgb48le",
+            "pipe:1",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn();
+
+    if let Ok(child) = hw_result {
+        return Ok(child);
+    } else if let Err(ref e) = hw_result {
+        log::debug!("nvdec 16-bit spawn failed ({e}), falling back to software decode");
+    }
+
+    // Software fallback
+    Command::new("ffmpeg")
+        .args([
+            "-i", input_str,
+            "-vf", &format!("scale={size_str}"),
+            "-f", "rawvideo",
+            "-pix_fmt", "rgb48le",
+            "pipe:1",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(FfmpegError::NotFound)
+}
+
+struct FrameReader16 {
+    child: Child,
+    frame_index: u64,
+    width: usize,
+    height: usize,
+    /// Number of bytes per frame (width * height * 3 * 2).
+    frame_bytes: usize,
+    done: bool,
+}
+
+impl FrameReader16 {
+    fn new(child: Child, width: usize, height: usize) -> Self {
+        Self {
+            child,
+            frame_index: 0,
+            width,
+            height,
+            frame_bytes: width * height * 3 * 2, // 6 bytes per pixel (rgb48le)
+            done: false,
+        }
+    }
+}
+
+impl Drop for FrameReader16 {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Iterator for FrameReader16 {
+    type Item = Result<Frame16, FfmpegError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let mut raw = vec![0u8; self.frame_bytes];
+        let stdout = self.child.stdout.as_mut()?;
+
+        match read_exact(stdout, &mut raw) {
+            Ok(0) | Err(_) => {
+                self.done = true;
+                return None;
+            }
+            Ok(_) => {}
+        }
+
+        // Convert LE byte pairs → u16
+        let n_pixels = self.width * self.height * 3;
+        let mut pixels = Vec::with_capacity(n_pixels);
+        for chunk in raw.chunks_exact(2) {
+            pixels.push(u16::from_le_bytes([chunk[0], chunk[1]]));
+        }
+
+        let frame = Frame16 {
+            index: self.frame_index,
+            pixels,
+            width: self.width,
+            height: self.height,
+        };
+        self.frame_index += 1;
+        Some(Ok(frame))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FrameEncoder
+// ---------------------------------------------------------------------------
+
 /// Encoder for streaming frames to an output video file.
 pub struct FrameEncoder {
     child: Child,
@@ -779,6 +926,23 @@ mod tests {
         assert_eq!(InputEncoding::DLogM.to_string(), "dlog-m");
         assert_eq!(InputEncoding::ILog.to_string(), "ilog");
         assert_eq!(InputEncoding::Srgb.to_string(), "srgb");
+    }
+
+    // ---- Task 6 tests ----
+
+    #[test]
+    fn frame16_to_8bit() {
+        // u16 value 0xFF00 should downshift to 0xFF.
+        let frame = Frame16 {
+            index: 0,
+            pixels: vec![0xFF00u16, 0x8000u16, 0x0100u16],
+            width: 1,
+            height: 1,
+        };
+        let eight = frame.to_8bit();
+        assert_eq!(eight[0], 0xFF);
+        assert_eq!(eight[1], 0x80);
+        assert_eq!(eight[2], 0x01);
     }
 
     #[test]

--- a/crates/dorea-video/src/ffmpeg.rs
+++ b/crates/dorea-video/src/ffmpeg.rs
@@ -37,12 +37,8 @@ pub enum InputEncoding {
 
 impl InputEncoding {
     /// Heuristic: infer encoding from `VideoInfo` and the file path extension.
-    pub fn auto_detect(info: &VideoInfo, path: &std::path::Path) -> Self {
-        let ext = path
-            .extension()
-            .map(|e| e.to_string_lossy().to_lowercase())
-            .unwrap_or_default();
-        if info.codec_name == "prores" || ext == "mov" {
+    pub fn auto_detect(info: &VideoInfo, _path: &std::path::Path) -> Self {
+        if info.codec_name == "prores" {
             return Self::ILog;
         }
         if info.bits_per_component >= 10
@@ -578,8 +574,7 @@ struct FrameReader16 {
     frame_index: u64,
     width: usize,
     height: usize,
-    /// Number of bytes per frame (width * height * 3 * 2).
-    frame_bytes: usize,
+    read_buf: Vec<u8>,
     done: bool,
 }
 
@@ -590,7 +585,7 @@ impl FrameReader16 {
             frame_index: 0,
             width,
             height,
-            frame_bytes: width * height * 3 * 2, // 6 bytes per pixel (rgb48le)
+            read_buf: vec![0u8; width * height * 6],
             done: false,
         }
     }
@@ -611,10 +606,9 @@ impl Iterator for FrameReader16 {
             return None;
         }
 
-        let mut raw = vec![0u8; self.frame_bytes];
         let stdout = self.child.stdout.as_mut()?;
 
-        match read_exact(stdout, &mut raw) {
+        match read_exact(stdout, &mut self.read_buf) {
             Ok(0) | Err(_) => {
                 self.done = true;
                 return None;
@@ -625,7 +619,7 @@ impl Iterator for FrameReader16 {
         // Convert LE byte pairs → u16
         let n_pixels = self.width * self.height * 3;
         let mut pixels = Vec::with_capacity(n_pixels);
-        for chunk in raw.chunks_exact(2) {
+        for chunk in self.read_buf.chunks_exact(2) {
             pixels.push(u16::from_le_bytes([chunk[0], chunk[1]]));
         }
 
@@ -650,6 +644,7 @@ pub struct FrameEncoder {
     stdin: ChildStdin,
     stderr: Option<ChildStderr>,
     frame_bytes: usize,
+    write_buf: Vec<u8>,
 }
 
 impl FrameEncoder {
@@ -745,6 +740,7 @@ impl FrameEncoder {
             stdin,
             stderr,
             frame_bytes: width * height * 3,
+            write_buf: Vec::new(),
         })
     }
 
@@ -807,6 +803,7 @@ impl FrameEncoder {
             stdin,
             stderr,
             frame_bytes: width * height * 3,
+            write_buf: Vec::new(),
         })
     }
 
@@ -944,6 +941,7 @@ impl FrameEncoder {
             stdin,
             stderr,
             frame_bytes: width * height * bytes_per_pixel,
+            write_buf: Vec::new(),
         })
     }
 
@@ -982,17 +980,19 @@ impl FrameEncoder {
     /// Converts the u16 slice to little-endian bytes and forwards to the encoder stdin.
     /// The slice length must equal `width * height * 3`.
     pub fn write_frame_16(&mut self, pixels: &[u16]) -> Result<(), FfmpegError> {
-        // 2 bytes per u16
-        let expected_u16 = self.frame_bytes / 2;
-        if pixels.len() != expected_u16 {
+        let expected_bytes = pixels.len() * 2;
+        if expected_bytes != self.frame_bytes {
             return Err(FfmpegError::EncodeFailed(format!(
-                "frame16 size mismatch: expected {} u16 values, got {}",
-                expected_u16,
-                pixels.len()
+                "16-bit frame size mismatch: expected {} bytes, got {}",
+                self.frame_bytes, expected_bytes
             )));
         }
-        let bytes: Vec<u8> = pixels.iter().flat_map(|&v| v.to_le_bytes()).collect();
-        if let Err(e) = self.stdin.write_all(&bytes) {
+        self.write_buf.clear();
+        self.write_buf.reserve(expected_bytes);
+        for &v in pixels {
+            self.write_buf.extend_from_slice(&v.to_le_bytes());
+        }
+        if let Err(e) = self.stdin.write_all(&self.write_buf) {
             let stderr_msg = self.stderr.as_mut().map(|s| {
                 let mut buf = String::new();
                 let _ = s.read_to_string(&mut buf);

--- a/crates/dorea-video/src/ffmpeg.rs
+++ b/crates/dorea-video/src/ffmpeg.rs
@@ -84,6 +84,60 @@ impl std::str::FromStr for InputEncoding {
 }
 
 // ---------------------------------------------------------------------------
+// OutputCodec — codec family for the encoded output
+// ---------------------------------------------------------------------------
+
+/// Codec family for the encoded output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputCodec {
+    /// Apple ProRes 422 HQ (10-bit, .mov).
+    ProRes,
+    /// HEVC / H.265 Main 10 profile (10-bit, .mp4 / .mov).
+    Hevc10,
+    /// H.264 (8-bit, .mp4).
+    H264,
+}
+
+impl OutputCodec {
+    /// Returns `true` for codecs that carry 10-bit colour data.
+    pub fn is_10bit(&self) -> bool {
+        matches!(self, Self::ProRes | Self::Hevc10)
+    }
+
+    /// Bytes per pixel in the raw frame buffer consumed by this codec's encoder.
+    ///
+    /// - 8-bit RGB (H264): 3 bytes/pixel
+    /// - 16-bit RGB48 (ProRes, Hevc10): 6 bytes/pixel
+    pub fn bytes_per_pixel(&self) -> usize {
+        if self.is_10bit() { 6 } else { 3 }
+    }
+}
+
+impl std::fmt::Display for OutputCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProRes => write!(f, "prores"),
+            Self::Hevc10 => write!(f, "hevc10"),
+            Self::H264 => write!(f, "h264"),
+        }
+    }
+}
+
+impl std::str::FromStr for OutputCodec {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s.to_lowercase().as_str() {
+            "prores" | "prores_ks" => Ok(Self::ProRes),
+            "hevc10" | "hevc" | "h265" | "h265_10" => Ok(Self::Hevc10),
+            "h264" | "avc" => Ok(Self::H264),
+            other => Err(format!(
+                "unknown codec '{other}'; expected prores, hevc10, or h264"
+            )),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // VideoInfo
 // ---------------------------------------------------------------------------
 
@@ -756,6 +810,143 @@ impl FrameEncoder {
         })
     }
 
+    /// Spawn a 10-bit encoder subprocess.
+    ///
+    /// Accepts `rgb48le` raw frames (6 bytes/pixel) from `write_frame_16`.
+    /// Codec selection:
+    /// - `OutputCodec::ProRes` → `prores_ks -profile:v 3 -pix_fmt yuv422p10le`
+    /// - `OutputCodec::Hevc10` → `hevc_nvenc -profile:v main10` (fallback: `libx265 -profile:v main10`)
+    /// - `OutputCodec::H264`  → standard H.264 (ffmpeg down-converts rgb48le → yuv420p)
+    pub fn new_10bit(
+        output: &Path,
+        width: usize,
+        height: usize,
+        fps: f64,
+        codec: OutputCodec,
+        input_for_audio: Option<&Path>,
+    ) -> Result<Self, FfmpegError> {
+        if let Some(parent) = output.parent() {
+            if !parent.as_os_str().is_empty() && !parent.exists() {
+                return Err(FfmpegError::EncodeFailed(format!(
+                    "output directory does not exist: {}",
+                    parent.display()
+                )));
+            }
+        }
+
+        let fps_s = format!("{fps:.3}");
+        let size_s = format!("{width}x{height}");
+        let out_s = output.to_str().unwrap_or("output.mov");
+
+        let bytes_per_pixel = codec.bytes_per_pixel();
+        // For rgb48le the pixel_format name ffmpeg understands:
+        let input_pix_fmt = if codec.is_10bit() { "rgb48le" } else { "rgb24" };
+
+        let mut cmd = Command::new("ffmpeg");
+        cmd.args([
+            "-y",
+            "-f", "rawvideo",
+            "-pixel_format", input_pix_fmt,
+            "-s", &size_s,
+            "-r", &fps_s,
+            "-i", "pipe:0",
+        ]);
+
+        if let Some(audio_src) = input_for_audio {
+            cmd.args(["-i", audio_src.to_str().unwrap_or("")]);
+            cmd.args(["-map", "0:v", "-map", "1:a", "-c:a", "copy"]);
+        } else {
+            cmd.args(["-map", "0:v"]);
+        }
+
+        match codec {
+            OutputCodec::ProRes => {
+                cmd.args([
+                    "-c:v", "prores_ks",
+                    "-profile:v", "3",        // ProRes 422 HQ
+                    "-pix_fmt", "yuv422p10le",
+                ]);
+            }
+            OutputCodec::Hevc10 => {
+                // Cache HEVC NVENC availability separately from H.264 NVENC.
+                static HEVC_NVENC_AVAILABLE: OnceLock<bool> = OnceLock::new();
+                let hevc_nvenc = *HEVC_NVENC_AVAILABLE.get_or_init(|| {
+                    Command::new("ffmpeg")
+                        .args(["-hide_banner", "-encoders"])
+                        .output()
+                        .map(|o| String::from_utf8_lossy(&o.stdout).contains("hevc_nvenc"))
+                        .unwrap_or(false)
+                });
+
+                if hevc_nvenc {
+                    cmd.args([
+                        "-c:v", "hevc_nvenc",
+                        "-profile:v", "main10",
+                        "-pix_fmt", "p010le",
+                    ]);
+                } else {
+                    cmd.args([
+                        "-c:v", "libx265",
+                        "-profile:v", "main10",
+                        "-pix_fmt", "yuv420p10le",
+                        "-crf", "18",
+                        "-preset", "fast",
+                    ]);
+                }
+            }
+            OutputCodec::H264 => {
+                // ffmpeg will handle the rgb48le → yuv420p downconversion.
+                static NVENC_AVAILABLE_10: OnceLock<bool> = OnceLock::new();
+                let nvenc = *NVENC_AVAILABLE_10.get_or_init(|| {
+                    Command::new("ffmpeg")
+                        .args(["-hide_banner", "-encoders"])
+                        .output()
+                        .map(|o| String::from_utf8_lossy(&o.stdout).contains("h264_nvenc"))
+                        .unwrap_or(false)
+                });
+
+                if nvenc {
+                    cmd.args(["-c:v", "h264_nvenc", "-preset", "p4", "-cq", "18"]);
+                } else {
+                    cmd.args(["-c:v", "libx264", "-crf", "18", "-preset", "fast"]);
+                }
+            }
+        }
+
+        cmd.arg(out_s);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(FfmpegError::NotFound)?;
+        let stdin = child.stdin.take().ok_or_else(|| {
+            FfmpegError::EncodeFailed("could not open 10-bit encoder stdin".to_string())
+        })?;
+        let stderr = child.stderr.take();
+
+        if let Ok(Some(status)) = child.try_wait() {
+            let msg = stderr
+                .map(|mut s| {
+                    let mut buf = String::new();
+                    let _ = s.read_to_string(&mut buf);
+                    buf
+                })
+                .unwrap_or_default();
+            return Err(FfmpegError::EncodeFailed(format!(
+                "10-bit ffmpeg encoder exited immediately (code {:?}): {}",
+                status.code(),
+                msg.trim()
+            )));
+        }
+
+        Ok(Self {
+            child,
+            stdin,
+            stderr,
+            frame_bytes: width * height * bytes_per_pixel,
+        })
+    }
+
     /// Write one RGB24 frame to the encoder.
     pub fn write_frame(&mut self, pixels: &[u8]) -> Result<(), FfmpegError> {
         if pixels.len() != self.frame_bytes {
@@ -767,6 +958,41 @@ impl FrameEncoder {
         }
         if let Err(e) = self.stdin.write_all(pixels) {
             // Broken pipe means ffmpeg exited — check its stderr for a real error message.
+            let stderr_msg = self.stderr.as_mut().map(|s| {
+                let mut buf = String::new();
+                let _ = s.read_to_string(&mut buf);
+                buf
+            }).unwrap_or_default();
+            let exit_code = self.child.try_wait().ok().flatten()
+                .and_then(|s| s.code())
+                .map(|c| format!(" (exit code {c})"))
+                .unwrap_or_default();
+            let detail = if stderr_msg.trim().is_empty() {
+                format!("{e}{exit_code}")
+            } else {
+                format!("{}{exit_code}: {}", e, stderr_msg.trim())
+            };
+            return Err(FfmpegError::EncodeFailed(format!("ffmpeg encoder died: {detail}")));
+        }
+        Ok(())
+    }
+
+    /// Write one RGB48 frame (as `&[u16]`) to a 10-bit encoder.
+    ///
+    /// Converts the u16 slice to little-endian bytes and forwards to the encoder stdin.
+    /// The slice length must equal `width * height * 3`.
+    pub fn write_frame_16(&mut self, pixels: &[u16]) -> Result<(), FfmpegError> {
+        // 2 bytes per u16
+        let expected_u16 = self.frame_bytes / 2;
+        if pixels.len() != expected_u16 {
+            return Err(FfmpegError::EncodeFailed(format!(
+                "frame16 size mismatch: expected {} u16 values, got {}",
+                expected_u16,
+                pixels.len()
+            )));
+        }
+        let bytes: Vec<u8> = pixels.iter().flat_map(|&v| v.to_le_bytes()).collect();
+        if let Err(e) = self.stdin.write_all(&bytes) {
             let stderr_msg = self.stderr.as_mut().map(|s| {
                 let mut buf = String::new();
                 let _ = s.read_to_string(&mut buf);
@@ -943,6 +1169,39 @@ mod tests {
         assert_eq!(eight[0], 0xFF);
         assert_eq!(eight[1], 0x80);
         assert_eq!(eight[2], 0x01);
+    }
+
+    // ---- Task 7 tests ----
+
+    #[test]
+    fn output_codec_is_10bit() {
+        assert!(OutputCodec::ProRes.is_10bit());
+        assert!(OutputCodec::Hevc10.is_10bit());
+        assert!(!OutputCodec::H264.is_10bit());
+    }
+
+    #[test]
+    fn output_codec_bytes_per_pixel() {
+        assert_eq!(OutputCodec::ProRes.bytes_per_pixel(), 6);
+        assert_eq!(OutputCodec::Hevc10.bytes_per_pixel(), 6);
+        assert_eq!(OutputCodec::H264.bytes_per_pixel(), 3);
+    }
+
+    #[test]
+    fn output_codec_parse() {
+        assert_eq!("prores".parse::<OutputCodec>(), Ok(OutputCodec::ProRes));
+        assert_eq!("hevc10".parse::<OutputCodec>(), Ok(OutputCodec::Hevc10));
+        assert_eq!("hevc".parse::<OutputCodec>(), Ok(OutputCodec::Hevc10));
+        assert_eq!("h264".parse::<OutputCodec>(), Ok(OutputCodec::H264));
+        assert_eq!("avc".parse::<OutputCodec>(), Ok(OutputCodec::H264));
+        assert!("unknown".parse::<OutputCodec>().is_err());
+    }
+
+    #[test]
+    fn output_codec_display() {
+        assert_eq!(OutputCodec::ProRes.to_string(), "prores");
+        assert_eq!(OutputCodec::Hevc10.to_string(), "hevc10");
+        assert_eq!(OutputCodec::H264.to_string(), "h264");
     }
 
     #[test]

--- a/dorea.toml
+++ b/dorea.toml
@@ -24,6 +24,8 @@ base_lut_zones       = 32    # base LUT zones per scene segment (color science)
 scene_threshold      = 0.15  # Wasserstein-1 depth distance to split scene segments [0.0–1.0]
 min_segment_keyframes = 3    # merge segments shorter than this into the previous one
 zone_smoothing_window = 3    # moving-average window for per-KF zone boundary smoothing
+# input_encoding = "auto"    # auto-detect from container/codec; options: dlog-m, ilog, srgb
+# output_codec = "auto"      # auto: prores for 10-bit, h264 for 8-bit; options: prores, hevc10, h264
 
 [maxine]
 upscale_factor     = 2       # SR factor: 2, 3, or 4 (used when SR is re-enabled)


### PR DESCRIPTION
## Summary
- Add 10-bit video I/O pipeline supporting DJI Action 4 (D-Log M H.265) and Insta360 X5 (I-Log ProRes)
- TransferFunction trait abstracts camera log curves with DLogM, ILog, and LutBased implementations
- CUDA kernel variant `combined_lut_kernel_16` for u16 I/O at full 10-bit precision
- ProRes 422 HQ and HEVC 10-bit output encoding

## Changes
- **dorea-color**: TransferFunction trait, DLogM/ILog/LutBased implementations
- **dorea-video**: VideoInfo codec detection, InputEncoding auto-detect, Frame16 + 10-bit decode (rgb48le), OutputCodec + 10-bit encode (ProRes/HEVC)
- **dorea-gpu**: `combined_lut_kernel_16` CUDA kernel (u16 I/O), FrameBuffers16, AdaptiveGrader::grade_frame_blended_16
- **dorea-cli**: `--input-encoding`, `--output-codec` flags, 10-bit grading stage, `dorea probe` subcommand, backward compat tests

## Test Plan
- [x] Unit tests pass (cargo test — 104 pass, 7 pre-existing failures)
- [x] Clippy: only pre-existing warnings
- [x] E2E: `dorea probe` correctly identifies DJI 10-bit HEVC as D-Log M
- [x] E2E: CLI --help shows new flags
- [x] Backward compat: 8-bit auto-detection defaults verified

## Review
5-persona review completed:
- Senior SWE: Approved after fixes (non-CUDA fallback, mask panic, .mov detect, buffer reuse)
- Product Manager: Approved — tiny planet deferred to follow-up issue
- QA Engineer: Approved after fixes (non-CUDA compile error, Box::leak, mask panic)
- Performance Engineer: Approved after fixes (write_frame_16 allocation, FrameReader16 buffer)
- Rust Idiom Reviewer: Approved after fixes (trait signature &str, Box::leak removal, .mov heuristic)

Closes chunzhe10/dorea-workspace#29

Generated with [Claude Code](https://claude.com/claude-code)