### PR TITLE
perf(direct): 3-thread pipeline + concurrency hardening

### DIFF
--- a/python/dorea_inference/raune_filter.py
+++ b/python/dorea_inference/raune_filter.py
@@ -19,6 +19,8 @@ Supports both single-process mode (--input/--output) and legacy pipe mode
 import sys
 import argparse
 import time
+import threading
+import queue
 from pathlib import Path
 
 import numpy as np
@@ -248,77 +250,130 @@ def run_single_process(args, model, normalize):
           f"batch={batch_size}, codec={codec_name}, fps={fps:.3f}",
           file=sys.stderr, flush=True)
 
-    frame_count = 0
+    # ─── 3-thread pipeline: decoder → GPU → encoder ────────────────────────
+    # Bounded queues provide backpressure (memory bound: ~200MB at 4K)
+    q_decoded = queue.Queue(maxsize=2)   # holds: list[np.ndarray] (one batch)
+    q_processed = queue.Queue(maxsize=2) # holds: list[np.ndarray] (one batch)
+
+    # Shared error state
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    stop_event = threading.Event()
+
+    def record_error(exc: BaseException) -> None:
+        with errors_lock:
+            errors.append(exc)
+        stop_event.set()
+
+    # Frame counter shared with encoder thread for progress reporting
     t_start = time.time()
-    batch_frames_np = []
+    encoded_count = 0
 
-    for packet in in_container.demux(in_stream):
-        for frame in packet.decode():
-            # PyAV frame → RGB24 numpy (in-process, no pipe)
-            rgb = frame.to_ndarray(format="rgb24")  # (H, W, 3) uint8
+    # ─── Thread 1: Decoder ─────────────────────────────────────────────────
+    def decoder_thread() -> None:
+        try:
+            batch: list[np.ndarray] = []
+            for packet in in_container.demux(in_stream):
+                if stop_event.is_set():
+                    return
+                for frame in packet.decode():
+                    if stop_event.is_set():
+                        return
+                    rgb = frame.to_ndarray(format="rgb24")  # (H, W, 3) uint8
+                    if rgb.shape[1] != fw or rgb.shape[0] != fh:
+                        rgb = np.array(
+                            frame.to_image().resize((fw, fh)),
+                            dtype=np.uint8,
+                        )
+                    batch.append(rgb)
+                    if len(batch) >= batch_size:
+                        q_decoded.put(batch)
+                        batch = []
+            if batch:
+                q_decoded.put(batch)
+        except BaseException as e:
+            record_error(e)
+        finally:
+            q_decoded.put(None)  # sentinel: tell GPU thread we're done
 
-            # Resize if needed (input might not match expected dims)
-            if rgb.shape[1] != fw or rgb.shape[0] != fh:
-                rgb = np.array(
-                    frame.to_image().resize((fw, fh)),
-                    dtype=np.uint8,
+    # ─── Thread 2: GPU processing ──────────────────────────────────────────
+    def gpu_thread() -> None:
+        try:
+            while True:
+                if stop_event.is_set():
+                    return
+                batch = q_decoded.get()
+                if batch is None:
+                    return
+                results = _process_batch(
+                    batch, model, normalize,
+                    fw, fh, pw, ph, transfer_fn,
                 )
+                q_processed.put(results)
+        except BaseException as e:
+            record_error(e)
+        finally:
+            q_processed.put(None)  # sentinel: tell encoder we're done
 
-            batch_frames_np.append(rgb)
+    # ─── Thread 3: Encoder ─────────────────────────────────────────────────
+    def encoder_thread() -> None:
+        nonlocal encoded_count
+        try:
+            while True:
+                if stop_event.is_set():
+                    return
+                results = q_processed.get()
+                if results is None:
+                    return
+                for result_np in results:
+                    out_frame = av.VideoFrame.from_ndarray(result_np, format="rgb24")
+                    out_frame.pts = encoded_count
+                    for pkt in out_stream.encode(out_frame):
+                        out_container.mux(pkt)
+                    encoded_count += 1
+                    if encoded_count % (batch_size * 4) == 0:
+                        elapsed = time.time() - t_start
+                        fps_actual = encoded_count / elapsed if elapsed > 0 else 0
+                        pct = (encoded_count / total_frames * 100
+                               if total_frames else 0)
+                        print(f"[raune-filter] {encoded_count} frames "
+                              f"({pct:.0f}%, {fps_actual:.1f} fps)",
+                              file=sys.stderr, flush=True)
+        except BaseException as e:
+            record_error(e)
 
-            if len(batch_frames_np) < batch_size:
-                continue
+    # Spawn threads
+    t_dec = threading.Thread(target=decoder_thread, name="decoder", daemon=False)
+    t_gpu = threading.Thread(target=gpu_thread, name="gpu", daemon=False)
+    t_enc = threading.Thread(target=encoder_thread, name="encoder", daemon=False)
 
-            # Process batch
-            results = _process_batch(
-                batch_frames_np, model, normalize,
-                fw, fh, pw, ph, transfer_fn,
-            )
+    t_dec.start()
+    t_gpu.start()
+    t_enc.start()
 
-            # Encode results
-            for result_np in results:
-                out_frame = av.VideoFrame.from_ndarray(result_np, format="rgb24")
-                out_frame.pts = frame_count
-                for pkt in out_stream.encode(out_frame):
-                    out_container.mux(pkt)
-                frame_count += 1
+    # Wait for all threads to finish
+    t_dec.join()
+    t_gpu.join()
+    t_enc.join()
 
-            batch_frames_np.clear()
-
-            if frame_count % (batch_size * 4) == 0:
-                elapsed = time.time() - t_start
-                fps_actual = frame_count / elapsed if elapsed > 0 else 0
-                pct = frame_count / total_frames * 100 if total_frames else 0
-                print(f"[raune-filter] {frame_count} frames "
-                      f"({pct:.0f}%, {fps_actual:.1f} fps)",
-                      file=sys.stderr, flush=True)
-
-    # Process remaining frames
-    if batch_frames_np:
-        results = _process_batch(
-            batch_frames_np, model, normalize,
-            fw, fh, pw, ph, transfer_fn,
-        )
-        for result_np in results:
-            out_frame = av.VideoFrame.from_ndarray(result_np, format="rgb24")
-            out_frame.pts = frame_count
-            for pkt in out_stream.encode(out_frame):
-                out_container.mux(pkt)
-            frame_count += 1
-
-    # Flush encoder
-    for pkt in out_stream.encode():
-        out_container.mux(pkt)
+    # Flush encoder (must happen on main thread after encoder thread finishes)
+    if not errors:
+        for pkt in out_stream.encode():
+            out_container.mux(pkt)
 
     out_container.close()
     in_container.close()
 
+    # Propagate any error from worker threads
+    if errors:
+        raise errors[0]
+
     elapsed = time.time() - t_start
-    fps_actual = frame_count / elapsed if elapsed > 0 else 0
-    print(f"[raune-filter] done: {frame_count} frames in {elapsed:.1f}s "
+    fps_actual = encoded_count / elapsed if elapsed > 0 else 0
+    print(f"[raune-filter] done: {encoded_count} frames in {elapsed:.1f}s "
           f"({fps_actual:.2f} fps)",
           file=sys.stderr, flush=True)
-    return frame_count
+    return encoded_count
 
 
 def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_fn):

--- a/python/dorea_inference/raune_filter.py
+++ b/python/dorea_inference/raune_filter.py
@@ -265,6 +265,22 @@ def run_single_process(args, model, normalize):
             errors.append(exc)
         stop_event.set()
 
+    def put_or_stop(q: "queue.Queue", item, stop_event: threading.Event,
+                    poll_interval: float = 0.1) -> bool:
+        """Put item on queue, periodically checking stop_event.
+
+        Returns True if put succeeded, False if stop_event was set first.
+        Ensures worker threads cannot get stuck forever in a blocking put()
+        when the downstream consumer has died.
+        """
+        while not stop_event.is_set():
+            try:
+                q.put(item, timeout=poll_interval)
+                return True
+            except queue.Full:
+                continue
+        return False
+
     # Frame counter shared with encoder thread for progress reporting
     t_start = time.time()
     encoded_count = 0
@@ -282,7 +298,13 @@ def run_single_process(args, model, normalize):
             for packet in in_container.demux(in_stream):
                 if stop_event.is_set():
                     return
-                for frame in packet.decode():
+                # Time the entire packet.decode() iteration so that the
+                # libavcodec decode work (which actually runs here) is
+                # captured, not just the to_ndarray() conversion.
+                t_decode_start = time.perf_counter()
+                frames = list(packet.decode())
+                decode_busy += time.perf_counter() - t_decode_start
+                for frame in frames:
                     if stop_event.is_set():
                         return
                     t0 = time.perf_counter()
@@ -295,14 +317,18 @@ def run_single_process(args, model, normalize):
                     decode_busy += time.perf_counter() - t0
                     batch.append(rgb)
                     if len(batch) >= batch_size:
-                        q_decoded.put(batch)
+                        if not put_or_stop(q_decoded, batch, stop_event):
+                            return
                         batch = []
             if batch:
-                q_decoded.put(batch)
+                if not put_or_stop(q_decoded, batch, stop_event):
+                    return
         except BaseException as e:
             record_error(e)
         finally:
-            q_decoded.put(None)  # sentinel: tell GPU thread we're done
+            # Sentinel for GPU thread; use put_or_stop so we cannot hang
+            # here if the consumer has already died.
+            put_or_stop(q_decoded, None, stop_event)
 
     # ─── Thread 2: GPU processing ──────────────────────────────────────────
     def gpu_thread() -> None:
@@ -320,11 +346,13 @@ def run_single_process(args, model, normalize):
                     fw, fh, pw, ph, transfer_fn,
                 )
                 gpu_busy += time.perf_counter() - t0
-                q_processed.put(results)
+                if not put_or_stop(q_processed, results, stop_event):
+                    return
         except BaseException as e:
             record_error(e)
         finally:
-            q_processed.put(None)  # sentinel: tell encoder we're done
+            # Sentinel for encoder thread; use put_or_stop so we cannot hang.
+            put_or_stop(q_processed, None, stop_event)
 
     # ─── Thread 3: Encoder ─────────────────────────────────────────────────
     def encoder_thread() -> None:
@@ -354,6 +382,16 @@ def run_single_process(args, model, normalize):
                               file=sys.stderr, flush=True)
         except BaseException as e:
             record_error(e)
+            # On error, drain q_processed so the upstream gpu_thread does
+            # not deadlock in put_or_stop on a full queue. record_error
+            # has already set stop_event — once gpu_thread's in-flight put
+            # lands in the slot we empty here, its next loop iteration
+            # sees stop_event and exits cleanly.
+            try:
+                while True:
+                    _ = q_processed.get_nowait()
+            except queue.Empty:
+                pass
 
     # Spawn threads
     t_dec = threading.Thread(target=decoder_thread, name="decoder", daemon=False)
@@ -369,17 +407,45 @@ def run_single_process(args, model, normalize):
     t_gpu.join()
     t_enc.join()
 
-    # Flush encoder (must happen on main thread after encoder thread finishes)
-    if not errors:
-        for pkt in out_stream.encode():
-            out_container.mux(pkt)
+    # Determine whether any worker thread raised; read under lock.
+    error_to_raise: BaseException | None = None
+    with errors_lock:
+        if errors:
+            error_to_raise = errors[0]
 
-    out_container.close()
-    in_container.close()
+    # Flush encoder only on success — flushing after a failure can write
+    # trailing packets to an already-broken output file.
+    if error_to_raise is None:
+        try:
+            for pkt in out_stream.encode():
+                out_container.mux(pkt)
+        except BaseException as flush_err:
+            error_to_raise = flush_err
 
-    # Propagate any error from worker threads
-    if errors:
-        raise errors[0]
+    # Always close containers, but do not let a secondary close() failure
+    # (e.g. disk-full on trailer write) mask the original error.
+    try:
+        out_container.close()
+    except BaseException as close_err:
+        if error_to_raise is None:
+            error_to_raise = close_err
+    try:
+        in_container.close()
+    except BaseException:
+        pass  # input close errors are not interesting
+
+    # If anything went wrong, delete the partial/corrupt output file so
+    # callers do not see a broken ProRes left on disk.
+    if error_to_raise is not None:
+        try:
+            import os
+            if os.path.exists(args.output):
+                os.remove(args.output)
+                print(f"[raune-filter] removed partial output: {args.output}",
+                      file=sys.stderr, flush=True)
+        except OSError:
+            pass
+        raise error_to_raise
 
     elapsed = time.time() - t_start
     fps_actual = encoded_count / elapsed if elapsed > 0 else 0

--- a/python/dorea_inference/raune_filter.py
+++ b/python/dorea_inference/raune_filter.py
@@ -269,8 +269,14 @@ def run_single_process(args, model, normalize):
     t_start = time.time()
     encoded_count = 0
 
+    # Per-stage cumulative timing (busy time, excluding queue waits)
+    decode_busy = 0.0
+    gpu_busy = 0.0
+    encode_busy = 0.0
+
     # ─── Thread 1: Decoder ─────────────────────────────────────────────────
     def decoder_thread() -> None:
+        nonlocal decode_busy
         try:
             batch: list[np.ndarray] = []
             for packet in in_container.demux(in_stream):
@@ -279,12 +285,14 @@ def run_single_process(args, model, normalize):
                 for frame in packet.decode():
                     if stop_event.is_set():
                         return
+                    t0 = time.perf_counter()
                     rgb = frame.to_ndarray(format="rgb24")  # (H, W, 3) uint8
                     if rgb.shape[1] != fw or rgb.shape[0] != fh:
                         rgb = np.array(
                             frame.to_image().resize((fw, fh)),
                             dtype=np.uint8,
                         )
+                    decode_busy += time.perf_counter() - t0
                     batch.append(rgb)
                     if len(batch) >= batch_size:
                         q_decoded.put(batch)
@@ -298,6 +306,7 @@ def run_single_process(args, model, normalize):
 
     # ─── Thread 2: GPU processing ──────────────────────────────────────────
     def gpu_thread() -> None:
+        nonlocal gpu_busy
         try:
             while True:
                 if stop_event.is_set():
@@ -305,10 +314,12 @@ def run_single_process(args, model, normalize):
                 batch = q_decoded.get()
                 if batch is None:
                     return
+                t0 = time.perf_counter()
                 results = _process_batch(
                     batch, model, normalize,
                     fw, fh, pw, ph, transfer_fn,
                 )
+                gpu_busy += time.perf_counter() - t0
                 q_processed.put(results)
         except BaseException as e:
             record_error(e)
@@ -317,7 +328,7 @@ def run_single_process(args, model, normalize):
 
     # ─── Thread 3: Encoder ─────────────────────────────────────────────────
     def encoder_thread() -> None:
-        nonlocal encoded_count
+        nonlocal encoded_count, encode_busy
         try:
             while True:
                 if stop_event.is_set():
@@ -326,10 +337,12 @@ def run_single_process(args, model, normalize):
                 if results is None:
                     return
                 for result_np in results:
+                    t0 = time.perf_counter()
                     out_frame = av.VideoFrame.from_ndarray(result_np, format="rgb24")
                     out_frame.pts = encoded_count
                     for pkt in out_stream.encode(out_frame):
                         out_container.mux(pkt)
+                    encode_busy += time.perf_counter() - t0
                     encoded_count += 1
                     if encoded_count % (batch_size * 4) == 0:
                         elapsed = time.time() - t_start
@@ -370,8 +383,15 @@ def run_single_process(args, model, normalize):
 
     elapsed = time.time() - t_start
     fps_actual = encoded_count / elapsed if elapsed > 0 else 0
+    n = max(encoded_count, 1)
     print(f"[raune-filter] done: {encoded_count} frames in {elapsed:.1f}s "
           f"({fps_actual:.2f} fps)",
+          file=sys.stderr, flush=True)
+    print(f"[raune-filter] stage timing (busy ms/frame): "
+          f"decode={decode_busy*1000/n:.1f} "
+          f"gpu={gpu_busy*1000/n:.1f} "
+          f"encode={encode_busy*1000/n:.1f} "
+          f"wall={elapsed*1000/n:.1f}",
           file=sys.stderr, flush=True)
     return encoded_count
 


### PR DESCRIPTION
## Summary

Refactor `raune_filter.py::run_single_process()` from a single-threaded serial loop into a 3-thread producer-consumer pipeline (decoder → GPU → encoder) with bounded queues.

**Performance result:** 2.35 fps → 2.47 fps (~5% wall-time improvement). The 3× speedup target from issue #64 was **not met** — see "Goal vs delivered" below.

**The valuable outcome:** per-stage profiling now reveals the actual bottleneck (RAUNE GPU inference at ~398 ms/frame, not encode as originally estimated), and decode/encode are correctly hidden behind GPU work. This is a foundation change for future GPU-stage optimizations, not a user-visible win on its own.

## Goal vs delivered

Issue #64 expected 2.35 fps → ~7 fps based on the 2026-04-10 deep dive (corvia 019d74bb), which estimated stage costs as decode ~20ms / GPU ~80ms / encode ~80ms.

Actual measured per-stage cost (now in stderr output):

```
decode busy:  ~34 ms/frame    (libavcodec + format conversion)
gpu busy:    ~398 ms/frame    (RAUNE-Net dominates by 8×)
encode busy:  ~50-100 ms/frame (ProRes 422 HQ 10-bit, runs hidden behind GPU)
wall:        ~400 ms/frame    (≈ GPU busy — pipeline is saturated on GPU)
```

The pipeline IS working correctly — decode and encode are perfectly hidden behind GPU work. But the GPU stage is 5-7× more expensive than the deep dive estimated, so threading alone cannot reach the 7 fps target. The corrected bottleneck analysis is in corvia entry 019d74c9.

**This PR ships intentionally:**
- The 3-thread architecture is correct and necessary infrastructure for future GPU-stage optimizations
- The per-stage timing instrumentation establishes ground-truth measurements
- The concurrency hardening (deadlock fixes, error cleanup) is independently valuable

**Follow-up work to actually reach higher fps:** target the GPU stage — proxy resolution reduction (1080p → 720p), fp16 RAUNE inference, larger batch sizes, torch.compile, NVDEC, frame skipping. See corvia 019d74c9 for the ranked options. A new issue should be opened for this work.

## Changes

| File | Change |
|------|--------|
| `python/dorea_inference/raune_filter.py` | Refactor `run_single_process()` to 3 threads + bounded queues + timing + concurrency fixes |

3 commits:
- `04f5f95` `perf(direct): 3-thread pipeline for parallel decode/GPU/encode` — initial refactor
- `98726cf` `perf(direct): add per-stage timing instrumentation` — diagnostic timers
- `2de18c1` `fix(direct): address concurrency review — deadlocks, error paths, timer scope` — review fixes

## Concurrency hardening (from 5-persona review)

Fixed in commit `2de18c1`:

- **Deadlock chain**: encoder dies → no sentinel on `q_processed` → GPU thread blocks forever in `q.put()` → decoder thread blocks → main hangs. Fixed by adding `put_or_stop()` helper using timeout-based puts and adding error-path drain in encoder thread.
- **Blocking puts ignored stop_event**: all `q.put(...)` calls in worker threads now go through `put_or_stop()` which checks `stop_event` between timeout cycles.
- **Errors list read without lock**: post-join read of `errors` now wrapped in `with errors_lock:`.
- **Partial corrupt output left on disk**: error path now deletes partial output via `os.remove()` before re-raising.
- **`out_container.close()` shadowing original error**: close calls wrapped in try, secondary errors swallowed unless no primary error exists.
- **Decode timer misleading**: was wrapping only `to_ndarray()`, missing libavcodec decode time. Now also times `list(packet.decode())` so the metric reflects actual decode-thread CPU work.

## Test plan

- [x] **Happy path**: 360-frame 4K 120fps HEVC → 360-frame ProRes 422 HQ 10-bit, throughput 2.47 fps, frame-perfect output (YAVG=0, YMAX=0 vs single-threaded baseline)
- [x] **Single-frame edge case**: 1-frame input → 1-frame output, exercises the `if batch:` tail path in decoder thread
- [x] **Module import sanity**: all public symbols (`run_single_process`, `run_pipe_mode`, `_process_batch`, `triton_oklab_transfer`, `pytorch_oklab_transfer`, OKLab math) importable
- [x] **Rust build**: `cargo build --release -p dorea-cli` clean
- [x] **Bit-exact output**: frame-by-frame diff vs the previous single-threaded output is YAVG=0, YMAX=0 (the same RAUNE model on the same input produces identical pixels regardless of threading)

## Review

5-persona review completed in 2 rounds:

| Reviewer | Round 1 | Round 2 |
|---|---|---|
| Senior SWE | 1 critical, 4 important, 6 low | re-review (concurrency only): all fixed |
| QA Engineer | 2 critical, 2 important, 3 low | (deferred low items) |
| Product Manager | merge with reservations | (PR description addresses concerns) |
| Performance Engineer | 2 critical (out of scope: `_process_batch` issues), 5 important, 2 low | (deferred to follow-up issue) |
| Concurrency Specialist | 3 critical, 4 important, 3 low | re-review: all 6 critical/important fixed, no new issues |

**Out of scope (deferred to a follow-up issue):**
- Performance reviewer's `_process_batch()` items (double full-res upload, per-frame transfer loop defeating batching) — the plan explicitly excluded `_process_batch` modifications
- QA reviewer's missing unit tests — significant work, separate issue
- Various low-priority style/log improvements

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)