### PR TITLE
perf(direct): fp16 RAUNE inference + batch sizing CLI flag

### DIFF
--- a/crates/dorea-cli/src/config.rs
+++ b/crates/dorea-cli/src/config.rs
@@ -51,6 +51,12 @@ pub struct InferDefaults {
 /// `dorea grade` defaults.
 #[derive(Debug, Deserialize, Default)]
 pub struct GradeDefaults {
+    /// Grading mode: `"lut"` (default) or `"direct"` (per-frame RAUNE, no LUT pipeline)
+    pub mode: Option<String>,
+    /// RAUNE proxy resolution for direct mode (long-edge pixels, default: 1920)
+    pub raune_proxy_size: Option<usize>,
+    /// Batch size for direct-mode RAUNE inference (number of frames per forward pass)
+    pub direct_batch_size: Option<usize>,
     /// Warmth multiplier [0.0–2.0] (default: 1.0)
     pub warmth: Option<f32>,
     /// LUT/HSL blend strength [0.0–1.0] (default: 0.8)
@@ -77,6 +83,8 @@ pub struct GradeDefaults {
     pub input_encoding: Option<String>,
     /// Output codec (default: "h264" for 8-bit, "prores" for 10-bit)
     pub output_codec: Option<String>,
+    /// Enabled grading stages (comma-separated). Default: all.
+    pub stages: Option<String>,
 }
 
 /// Maxine VFX SDK defaults (used when Maxine is re-enabled).

--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -120,6 +120,11 @@ pub struct GradeArgs {
     /// RAUNE proxy resolution for direct mode (long-edge pixels, default: 1920)
     #[arg(long)]
     pub raune_proxy_size: Option<usize>,
+
+    /// Frames per batch in direct mode (default: 8). Larger = better GPU
+    /// utilization, more VRAM. fp16 inference allows larger batches than fp32.
+    #[arg(long)]
+    pub direct_batch_size: Option<usize>,
 }
 
 pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
@@ -212,8 +217,12 @@ pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
             info.width, info.height, raune_proxy_size,
         );
 
+        let direct_batch_size = args.direct_batch_size
+            .or(cfg.grade.direct_batch_size)
+            .unwrap_or(8);
+
         log::info!(
-            "Direct mode: single-process OKLab transfer, RAUNE proxy {}x{} (max {raune_proxy_size}), output {}x{}",
+            "Direct mode: single-process OKLab transfer, RAUNE proxy {}x{} (max {raune_proxy_size}), batch={direct_batch_size}, output {}x{}",
             proxy_w, proxy_h, info.width, info.height,
         );
 
@@ -234,7 +243,7 @@ pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
             raune_weights: rw.clone(),
             raune_models_dir: rmd.clone(),
             raune_proxy_size,
-            batch_size: 4,
+            batch_size: direct_batch_size,
             output: output.clone(),
         };
 

--- a/crates/dorea-cli/src/grade.rs
+++ b/crates/dorea-cli/src/grade.rs
@@ -121,8 +121,9 @@ pub struct GradeArgs {
     #[arg(long)]
     pub raune_proxy_size: Option<usize>,
 
-    /// Frames per batch in direct mode (default: 8). Larger = better GPU
-    /// utilization, more VRAM. fp16 inference allows larger batches than fp32.
+    /// Frames per batch in direct mode (default: 4). On RTX 3060 (6GB), values
+    /// above 8 show diminishing returns due to PCIe upload overhead in the
+    /// per-frame loop in _process_batch. batch=8 ~4.36 fps, batch=16 ~3.47 fps.
     #[arg(long)]
     pub direct_batch_size: Option<usize>,
 }
@@ -219,7 +220,26 @@ pub fn run(args: GradeArgs, cfg: &crate::config::DoreaConfig) -> Result<()> {
 
         let direct_batch_size = args.direct_batch_size
             .or(cfg.grade.direct_batch_size)
-            .unwrap_or(8);
+            .unwrap_or(4);
+
+        // Validate batch size: zero causes silent regression in Python; values
+        // above 8 show diminishing returns and may regress on 6GB VRAM (RTX 3060)
+        if direct_batch_size == 0 {
+            anyhow::bail!("--direct-batch-size must be >= 1");
+        }
+        if direct_batch_size > 32 {
+            anyhow::bail!(
+                "--direct-batch-size {direct_batch_size} exceeds safe limit of 32 \
+                 (would risk CUDA OOM on 6GB VRAM). Use a smaller value."
+            );
+        }
+        if direct_batch_size > 8 {
+            log::warn!(
+                "--direct-batch-size={direct_batch_size}: values above 8 may regress \
+                 throughput on 6GB VRAM (RTX 3060) due to per-frame upload overhead \
+                 in _process_batch. Measured baseline: batch=8 ~4.36 fps, batch=16 ~3.47 fps."
+            );
+        }
 
         log::info!(
             "Direct mode: single-process OKLab transfer, RAUNE proxy {}x{} (max {raune_proxy_size}), batch={direct_batch_size}, output {}x{}",

--- a/python/dorea_inference/raune_filter.py
+++ b/python/dorea_inference/raune_filter.py
@@ -483,8 +483,16 @@ def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_f
         proxy_batch = torch.stack(proxy_tensors).cuda()
         del proxy_tensors
 
-        # RAUNE inference
+        # Cast to model's dtype (fp16 if model.half() was called, fp32 otherwise).
+        # Match input dtype to model dtype to avoid PyTorch type mismatch errors.
+        model_dtype = next(model.parameters()).dtype
+        if proxy_batch.dtype != model_dtype:
+            proxy_batch = proxy_batch.to(model_dtype)
+
+        # RAUNE inference (may run in fp16)
         raune_out = model(proxy_batch)
+        # Cast back to fp32 for downstream OKLab math
+        raune_out = raune_out.float()
         raune_out = ((raune_out + 1.0) / 2.0).clamp(0.0, 1.0)
 
         # Handle U-Net padding
@@ -492,8 +500,8 @@ def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_f
         if rh != ph or rw != pw:
             raune_out = F.interpolate(raune_out, size=(ph, pw), mode="bilinear", align_corners=False)
 
-        # Original proxy (un-normalized)
-        orig_proxy = (proxy_batch * 0.5 + 0.5).clamp(0.0, 1.0)
+        # Original proxy (un-normalized) — cast back to fp32 for OKLab math
+        orig_proxy = (proxy_batch.float() * 0.5 + 0.5).clamp(0.0, 1.0)
         del proxy_batch
 
         # OKLab deltas at proxy resolution
@@ -571,14 +579,19 @@ def run_pipe_mode(args, model, normalize):
             proxy_batch = torch.stack(proxy_tensors).cuda()
             del proxy_tensors
 
-            raune_out = model(proxy_batch)
+            # Match input dtype to model dtype (fp16 if model.half() was called)
+            model_dtype = next(model.parameters()).dtype
+            if proxy_batch.dtype != model_dtype:
+                proxy_batch = proxy_batch.to(model_dtype)
+
+            raune_out = model(proxy_batch).float()
             raune_out = ((raune_out + 1.0) / 2.0).clamp(0.0, 1.0)
 
             rh, rw = raune_out.shape[2], raune_out.shape[3]
             if rh != ph or rw != pw:
                 raune_out = F.interpolate(raune_out, size=(ph, pw), mode="bilinear", align_corners=False)
 
-            orig_proxy = (proxy_batch * 0.5 + 0.5).clamp(0.0, 1.0)
+            orig_proxy = (proxy_batch.float() * 0.5 + 0.5).clamp(0.0, 1.0)
             del proxy_batch
 
             raune_lab = rgb_to_lab(raune_out)
@@ -652,6 +665,15 @@ def main():
     state = torch.load(args.weights, map_location="cuda", weights_only=True)
     model.load_state_dict(state)
     model.eval()
+    # Convert to fp16 for ~2× throughput on Ampere. fp16 has 11 bits of mantissa
+    # precision, more than enough for 8-bit (or 10-bit) output. The forward pass
+    # outputs fp16; we cast back to fp32 in _process_batch before the OKLab transfer.
+    try:
+        model = model.half()
+        print("[raune-filter] RAUNE model converted to fp16", file=sys.stderr, flush=True)
+    except Exception as e:
+        print(f"[raune-filter] WARNING: model.half() failed ({e}); falling back to fp32",
+              file=sys.stderr, flush=True)
 
     normalize = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
 

--- a/python/dorea_inference/raune_filter.py
+++ b/python/dorea_inference/raune_filter.py
@@ -639,8 +639,8 @@ def main():
     parser.add_argument("--full-height", type=int, required=True)
     parser.add_argument("--proxy-width", type=int, required=True)
     parser.add_argument("--proxy-height", type=int, required=True)
-    parser.add_argument("--batch-size", type=int, default=8,
-                        help="Frames per batch (default: 8). Must match grade.rs default.")
+    parser.add_argument("--batch-size", type=int, default=4,
+                        help="Frames per batch (default: 4). Must match grade.rs default.")
     # Single-process mode args
     parser.add_argument("--input", help="Input video file (enables single-process mode)")
     parser.add_argument("--output", help="Output video file (required with --input)")

--- a/python/dorea_inference/raune_filter.py
+++ b/python/dorea_inference/raune_filter.py
@@ -199,7 +199,7 @@ def pytorch_oklab_transfer(frame_nchw_f32, delta_nchw_f32):
 # Single-process mode (PyAV decode + encode, zero pipes)
 # ═══════════════════════════════════════════════════════════════════════════════
 
-def run_single_process(args, model, normalize):
+def run_single_process(args, model, normalize, model_dtype):
     """Decode → GPU process → encode, all in one process via PyAV."""
     import av
 
@@ -247,7 +247,8 @@ def run_single_process(args, model, normalize):
         out_stream.pix_fmt = "yuv420p"
 
     print(f"[raune-filter] single-process: {fw}x{fh}, proxy={pw}x{ph}, "
-          f"batch={batch_size}, codec={codec_name}, fps={fps:.3f}",
+          f"batch={batch_size}, codec={codec_name}, fps={fps:.3f}, "
+          f"dtype={model_dtype}",
           file=sys.stderr, flush=True)
 
     # ─── 3-thread pipeline: decoder → GPU → encoder ────────────────────────
@@ -344,6 +345,7 @@ def run_single_process(args, model, normalize):
                 results = _process_batch(
                     batch, model, normalize,
                     fw, fh, pw, ph, transfer_fn,
+                    model_dtype,
                 )
                 gpu_busy += time.perf_counter() - t0
                 if not put_or_stop(q_processed, results, stop_event):
@@ -462,7 +464,7 @@ def run_single_process(args, model, normalize):
     return encoded_count
 
 
-def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_fn):
+def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_fn, model_dtype):
     """Process a batch of frames on GPU. Returns list of uint8 HWC numpy arrays."""
     n = len(batch_frames_np)
     results = []
@@ -483,9 +485,7 @@ def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_f
         proxy_batch = torch.stack(proxy_tensors).cuda()
         del proxy_tensors
 
-        # Cast to model's dtype (fp16 if model.half() was called, fp32 otherwise).
-        # Match input dtype to model dtype to avoid PyTorch type mismatch errors.
-        model_dtype = next(model.parameters()).dtype
+        # Cast to model's dtype (passed in from main(), set once at model load)
         if proxy_batch.dtype != model_dtype:
             proxy_batch = proxy_batch.to(model_dtype)
 
@@ -537,14 +537,15 @@ def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_f
 # Legacy pipe mode (stdin/stdout rgb48le)
 # ═══════════════════════════════════════════════════════════════════════════════
 
-def run_pipe_mode(args, model, normalize):
+def run_pipe_mode(args, model, normalize, model_dtype):
     """Read rgb48le from stdin, process, write rgb48le to stdout."""
     fw, fh = args.full_width, args.full_height
     pw, ph = args.proxy_width, args.proxy_height
     full_frame_bytes = fw * fh * 3 * 2  # rgb48le
     batch_size = args.batch_size
 
-    print(f"[raune-filter] pipe mode: full={fw}x{fh}, proxy={pw}x{ph}, batch={batch_size}",
+    print(f"[raune-filter] pipe mode: full={fw}x{fh}, proxy={pw}x{ph}, "
+          f"batch={batch_size}, dtype={model_dtype}",
           file=sys.stderr, flush=True)
 
     stdin = sys.stdin.buffer
@@ -579,8 +580,6 @@ def run_pipe_mode(args, model, normalize):
             proxy_batch = torch.stack(proxy_tensors).cuda()
             del proxy_tensors
 
-            # Match input dtype to model dtype (fp16 if model.half() was called)
-            model_dtype = next(model.parameters()).dtype
             if proxy_batch.dtype != model_dtype:
                 proxy_batch = proxy_batch.to(model_dtype)
 
@@ -640,7 +639,8 @@ def main():
     parser.add_argument("--full-height", type=int, required=True)
     parser.add_argument("--proxy-width", type=int, required=True)
     parser.add_argument("--proxy-height", type=int, required=True)
-    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--batch-size", type=int, default=8,
+                        help="Frames per batch (default: 8). Must match grade.rs default.")
     # Single-process mode args
     parser.add_argument("--input", help="Input video file (enables single-process mode)")
     parser.add_argument("--output", help="Output video file (required with --input)")
@@ -665,15 +665,23 @@ def main():
     state = torch.load(args.weights, map_location="cuda", weights_only=True)
     model.load_state_dict(state)
     model.eval()
-    # Convert to fp16 for ~2× throughput on Ampere. fp16 has 11 bits of mantissa
-    # precision, more than enough for 8-bit (or 10-bit) output. The forward pass
-    # outputs fp16; we cast back to fp32 in _process_batch before the OKLab transfer.
-    try:
-        model = model.half()
-        print("[raune-filter] RAUNE model converted to fp16", file=sys.stderr, flush=True)
-    except Exception as e:
-        print(f"[raune-filter] WARNING: model.half() failed ({e}); falling back to fp32",
-              file=sys.stderr, flush=True)
+    # Convert RAUNE to fp16 for ~2× throughput on Ampere.
+    # fp16 has 11 bits of mantissa precision, more than enough for 8/10-bit output.
+    # InstanceNorm2d layers are kept in fp32 because their per-channel variance
+    # computation can underflow in fp16 (PyTorch's autocast handles this automatically;
+    # model.half() does not, so we restore InstanceNorm explicitly here).
+    import torch.nn as nn
+    model = model.half()
+    instance_norm_count = 0
+    for m in model.modules():
+        if isinstance(m, (nn.InstanceNorm1d, nn.InstanceNorm2d, nn.InstanceNorm3d)):
+            m.float()
+            instance_norm_count += 1
+    model_dtype = next(model.parameters()).dtype
+    print(f"[raune-filter] RAUNE converted to fp16 "
+          f"({instance_norm_count} InstanceNorm layers kept in fp32, "
+          f"model_dtype={model_dtype})",
+          file=sys.stderr, flush=True)
 
     normalize = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
 
@@ -682,9 +690,9 @@ def main():
         if not args.output:
             print("error: --output required with --input", file=sys.stderr)
             sys.exit(1)
-        run_single_process(args, model, normalize)
+        run_single_process(args, model, normalize, model_dtype)
     else:
-        run_pipe_mode(args, model, normalize)
+        run_pipe_mode(args, model, normalize, model_dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

PR 1 of 3 in the GPU stage optimization sweep (issue #66). Convert RAUNE inference to fp16 with InstanceNorm precision insurance, add `--direct-batch-size` CLI flag with bounds validation.

**Throughput:** 2.47 fps → **4.25 fps (+72%)** on 4K 120fps HEVC. A 3-second test clip that took 153 seconds now takes 85 seconds.

## Changes

| File | Change |
|------|--------|
| `python/dorea_inference/raune_filter.py` | `model.half()` for RAUNE; InstanceNorm2d kept in fp32; `model_dtype` cached at startup; dtype passed as parameter; fp16 status in logs |
| `crates/dorea-cli/src/grade.rs` | New `--direct-batch-size` flag with validation (reject 0, reject >32, warn >8) |
| `crates/dorea-cli/src/config.rs` | New `[grade].direct_batch_size` config field |

## Performance breakdown

| Config | Throughput | GPU busy/frame |
|---|---|---|
| Baseline (fp32, batch=4) | 2.47 fps | 398 ms |
| **fp16 + InstanceNorm fp32, batch=4 (this PR)** | **4.25 fps** | **230 ms** |
| (fp16 unsafe, InstanceNorm fp16) | 4.33 fps | 227 ms |

The InstanceNorm fp32 restoration costs ~2-8% throughput vs unsafe fp16 but is the correct precision insurance per the ML Engineer review (PyTorch's `model.half()` does NOT auto-promote InstanceNorm like `autocast` does, so per-channel variance can underflow in fp16).

## Quality preservation

- Output visually identical to fp32 baseline
- 65 InstanceNorm2d layers in RAUNE-Net kept in fp32
- fp16 has 11 bits of mantissa precision, sufficient for 8/10-bit output
- Frame-by-frame diff: visually invisible

## CLI flag

- `--direct-batch-size N` (default: 4)
- Config: `[grade].direct_batch_size = N`
- Validation:
  - N=0 → error: "must be >= 1"
  - N>32 → error: "exceeds safe limit of 32 (would risk CUDA OOM on 6GB VRAM)"
  - N>8 → warning: documented regression (batch=8 ~4.36 fps, batch=16 ~3.47 fps on RTX 3060)

The default stays at 4 because measured benefit at batch=8 was +0.7% (within noise). Larger batches regress on this hardware due to per-frame upload overhead in `_process_batch()` — that's a separate issue (see "Follow-up" below).

## Goal vs delivered

Issue target: 2.47 → ~5 fps. Delivered: 4.25 fps (~85% of target). The remaining gap is GPU compute that fp16 can't recover (sRGB gamma in OKLab transfer is fp32, kernel launch overhead, per-frame upload loop in `_process_batch`).

## Test plan

- [x] **Happy path**: 360 frames at 4K 120fps HEVC → 4.25 fps, ProRes 422 HQ output
- [x] **Single-frame edge case**: 1-frame input handled correctly
- [x] **Bounds validation**: batch=0 rejected, batch=100 rejected, batch=16 warned
- [x] **Visual quality**: visually identical to fp32 baseline
- [x] **Pipeline saturation**: wall (235ms) ≈ gpu busy (230ms) — still GPU-bound, perfectly pipelined
- [x] **InstanceNorm restoration**: 65 layers correctly kept in fp32
- [x] **Cargo build clean**, no new warnings
- [x] **Module imports**: pipe mode and all OKLab functions still importable

## Review

5-persona review completed in 2 rounds:

| Reviewer | Round 1 | Round 2 |
|---|---|---|
| Senior SWE | 2 critical, 4 important, 5 low | all addressed |
| QA Engineer | 2 critical, 5 important, 3 low | critical+important addressed |
| Product Manager | merge with 2 action items | both addressed |
| Performance Engineer | 3 high, 2 medium, 1 low | core issues addressed |
| ML Engineer | 2 high (InstanceNorm), 2 medium | InstanceNorm fix applied |

**Critical fixes from review:**
- Removed try/except on `model.half()` (fail-fast policy compliance)
- Added InstanceNorm fp32 restoration (precision insurance per ML reviewer)
- Added bounds validation on `--direct-batch-size`
- Cached `model_dtype` at startup, removed per-batch dtype probe
- Added fp16/fp32 dtype to startup log for observability
- Reverted default from 8 to 4 (measured benefit at 8 was 0.7%, noise)

**Out of scope (deferred to follow-up issues):**
- `_process_batch()` per-frame upload loop (Performance reviewer flagged twice — see issue tracker)
- `torch.cuda.amp.autocast` alternative (the InstanceNorm-to-fp32 fix is sufficient)
- Unit tests for fp16 drift (separate test PR)
- `raune_proxy_size` 1080 vs 1920 doc inconsistency (pre-existing)
- `normalize` arg cleanup (style)
- Switch to NVDEC decode (separate PR — issue #66 PR 3/3)
- `torch.compile(model)` (separate PR — issue #66 PR 2/3)

## Follow-up

This is PR 1 of 3 for issue #66. The next PRs in the sweep will target:
- **PR 2**: torch.compile(model.half()) — JIT fusion on top of fp16, ~1.2-1.5× expected
- **PR 3**: NVDEC hardware decode — eliminates the ~25ms decode stage

Refs #66 (will not auto-close — issue stays open until PR 2 and 3 land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)