### PR TITLE
perf: pinned memory for GPU upload/download (+5.8% FPS)

### DIFF
--- a/python/dorea_inference/raune_filter.py
+++ b/python/dorea_inference/raune_filter.py
@@ -482,8 +482,11 @@ def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_f
         # reinterprets as int16 (signed), corrupting values > 32767.
         full_gpu_cache = []
         proxy_tensors = []
+        # Pre-allocate pinned upload buffer (reused per frame, pin once not per-frame)
+        pinned_ul = torch.empty((fh, fw, 3), dtype=torch.int32, pin_memory=True)
         for rgb_np in batch_frames_np:
-            t_i32 = torch.from_numpy(rgb_np.astype(np.int32)).cuda()  # int32 on GPU
+            np.copyto(pinned_ul.numpy(), rgb_np.astype(np.int32))
+            t_i32 = pinned_ul.cuda(non_blocking=True)
             full_gpu_cache.append(t_i32)
             full_f32 = t_i32.float() / 65535.0                   # (H,W,3) fp32 [0,1]
             full_f32 = full_f32.permute(2, 0, 1).unsqueeze(0)    # (1,3,H,W)
@@ -529,6 +532,9 @@ def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_f
         delta_full = F.interpolate(delta_lab, size=(fh, fw), mode="bilinear", align_corners=False)
         del delta_lab
 
+        # Pre-allocate pinned host buffer for download (~3.5× faster than pageable)
+        pinned_dl = torch.empty((fh, fw, 3), dtype=torch.int32, pin_memory=True)
+
         # Apply transfer per frame — reuse GPU cache, no re-upload
         for i in range(n):
             full_t = full_gpu_cache[i].float() / 65535.0
@@ -537,11 +543,12 @@ def _process_batch(batch_frames_np, model, normalize, fw, fh, pw, ph, transfer_f
             result = transfer_fn(full_t, delta_full[i:i+1])
             del full_t
 
-            # GPU → CPU → uint16 (round-half-up to avoid systematic -0.5 LSB bias)
-            result_u16 = (result.squeeze(0).permute(1, 2, 0).clamp(0, 1) * 65535.0 + 0.5
-                         ).to(torch.int32).cpu().numpy().astype(np.uint16)
-            results.append(result_u16)
-            del result
+            # GPU → pinned CPU → uint16 (round-half-up to avoid systematic -0.5 LSB bias)
+            gpu_i32 = (result.squeeze(0).permute(1, 2, 0).clamp(0, 1) * 65535.0 + 0.5
+                      ).to(torch.int32)
+            pinned_dl.copy_(gpu_i32)
+            results.append(pinned_dl.numpy().astype(np.uint16))
+            del result, gpu_i32
 
         del full_gpu_cache, delta_full
 


### PR DESCRIPTION
## Summary
- Pre-allocated pinned memory buffers for int32 upload and download paths
- Modest but measurable improvement on the GPU bottleneck

## Measured Performance (4K footage, batch=4, TRT)

| Stage | Before | After | Δ |
|---|---|---|---|
| Decode (CPU) | 9.7ms | 22.7ms | +13ms (extra memcpy) |
| GPU busy | 198.6ms | 188.5ms | **-10ms** |
| Encode (CPU) | 67.6ms | 44.3ms | **-23ms** |
| Wall time | 230.9ms | 218.1ms | **-13ms** |
| **FPS** | **4.33** | **4.58** | **+5.8%** |

The decode regression is absorbed by pipeline overlap (decoder thread is 93% idle).
The GPU improvement is real because GPU is the bottleneck.
Encode improvement comes from faster downloads reaching the encoder.

## Quality
- PSNR vs baseline: 148dB (effectively identical — below 1 LSB difference)

## Context from earlier analysis (issue #76)

The issue estimated ~150ms savings per batch (~25% FPS gain). Measured breakdown
of the actual 10-bit pipeline showed the real bottlenecks were different:

| Stage | Actual | Estimated |
|---|---|---|
| TRT inference | 405ms (56%) | — |
| PCIe download | 186ms (26%) | 100ms |
| PCIe upload | 103ms (14%) | — |
| int32→float32 re-derivation | 5ms | 100ms ← wrong |

The `int32→float32` re-derivation I estimated at 100ms was actually 5ms — the
Triton apply kernel and cache management work out to be cheap. The real wins
are on PCIe transfers where pinned memory helps.

TRT inference at 56% of GPU time is the fundamental limit — beyond this requires
model changes.

## Test Plan
- [x] Pinned memory benchmarks verified (2.7× upload, 3.5× download)
- [x] Real 4K footage test shows +5.8% FPS
- [x] Quality unchanged (148dB PSNR)

Closes #76

Generated with [Claude Code](https://claude.com/claude-code)